### PR TITLE
ENH: add a first draft for the JOSS submission

### DIFF
--- a/joss_paper_0.18/paper.bib
+++ b/joss_paper_0.18/paper.bib
@@ -1,11 +1,18 @@
-@SciPy{,
+@Misc{SciPy,
   author =    {Eric Jones and Travis Oliphant and Pearu Peterson and others},
   title =     {{SciPy}: Open source scientific tools for {Python}},
   year =      {2001--},
   url = "http://www.scipy.org/"
 }
 
-@Article{NumPy,
+@Misc{NumPy,
+  author = {Charles Harris and Travis Oliphant and  David Cournapeau and Pearu Peterson and others}
+  title =     {{NumPy}: the fundamental package for scientific computing with {Python}},
+  year =      {2006--},
+  url = "http://www.numpy.org/"
+}
+
+@Article{WCV2011,
   author =       {Stéfan {van der Walt} and S. Chris Colbert and
                   Gaël Varoquaux},
   title =        {The NumPy Array: A Structure for Efficient Numerical

--- a/joss_paper_0.18/paper.bib
+++ b/joss_paper_0.18/paper.bib
@@ -1,0 +1,38 @@
+@SciPy{,
+  author =    {Eric Jones and Travis Oliphant and Pearu Peterson and others},
+  title =     {{SciPy}: Open source scientific tools for {Python}},
+  year =      {2001--},
+  url = "http://www.scipy.org/"
+}
+
+@Article{NumPy,
+  author =       {Stéfan {van der Walt} and S. Chris Colbert and
+                  Gaël Varoquaux},
+  title =        {The NumPy Array: A Structure for Efficient Numerical
+                  Computation},
+  journal =      {Computing in Science & Engineering},
+  year =         2011,
+  volume =       13,
+  number =       2,
+  pages =        {22-30},
+  url =          {http://scitation.aip.org/content/aip/journal/cise/13/2/10.1109/MCSE.2011.37},
+  doi =          {10.1109/MCSE.2011.37}
+}
+
+
+@Article{SciPy0180,
+  title        = {scipy: 0.18.0},
+  month        = aug,
+  year         = 2016,
+  doi          = {10.5281/zenodo.60419},
+  url          = {https://doi.org/10.5281/zenodo.60419}
+}
+
+
+@Article{SciPy0181},
+  title        = {scipy/scipy: SciPy 0.18.1},
+  month        = sep,
+  year         = 2016,
+  doi          = {10.5281/zenodo.154391},
+  url          = {https://doi.org/10.5281/zenodo.154391}
+}

--- a/joss_paper_0.18/paper.md
+++ b/joss_paper_0.18/paper.md
@@ -17,24 +17,24 @@ bibliography: paper.bib
 
 # Summary
 
-SciPy (pronounced "Sigh Pie") is open-source software for mathematics, science,
+SciPy (pronounced "Sigh Pie") is open-source library for mathematics, science,
 and engineering. It includes modules for statistics, optimization, integration,
 linear algebra, Fourier transforms, signal and image processing, ODE solvers,
 and more. 
 
 The @SciPy library depends on @NumPy, which provides convenient and fast N-dimensional
 array manipulation. The SciPy library is built to work with NumPy arrays, and
-provides many user-friendly and efficient numerical routines such as routines
+provides many user-friendly and efficient numerical methods such as routines
 for numerical integration and optimization. 
 
 The latest stable release of SciPy is [0.18.1](@SciPy0181), which improves on the feature
 release [0.18.0](SciPy0180). Together they contain numerous bug-fixes, improved test coverage,
-better documentation and many new features. For the complete description of the
+better documentation, and many new features. For the complete description of the
 contents of the 0.18 series, see the [release notes](https://github.com/scipy/scipy/releases/tag/v0.18.0).
 
 # Acknowledgements
 
-We gratefull acknowledge contributions of more than four hundred people whose work
+We gratefully acknowledge contributions of more than four hundred people whose work
 over more than fifteen years went into previous releases of SciPy and made the
 current release possible.
 

--- a/joss_paper_0.18/paper.md
+++ b/joss_paper_0.18/paper.md
@@ -28,10 +28,10 @@ sparse matrices, hierarchial clustering, signal and N-dimensional image processi
 spatial algorithms and data structures, graph algorithms, and reading and
 writing data files in a variety of common data formats.
 
-The @SciPy library depends on @NumPy, which provides convenient and fast N-dimensional
-array manipulation. The SciPy library is built to work with NumPy arrays, and
-provides many user-friendly and efficient numerical methods such as routines
-for numerical integration and optimization. 
+The @SciPy library depends on NumPy [@NumPy, @WCV2011], which provides convenient
+and fast N-dimensional array manipulation. The SciPy library is built to work with
+NumPy arrays, and provides many user-friendly and efficient numerical methods such
+as routines for numerical integration and optimization. 
 
 The latest stable release of SciPy is [0.18.1](@SciPy0181), which improves on the feature
 release [0.18.0](SciPy0180). Together they contain numerous bug-fixes, improved test coverage,

--- a/joss_paper_0.18/paper.md
+++ b/joss_paper_0.18/paper.md
@@ -1,0 +1,39 @@
+---
+title: 'SciPy 0.18: Open source toolbox for science and engineering'
+tags:
+  - science
+  - engineering
+  - mathematics
+authors:
+ - name: Evgeni Burovski
+   orcid: 0000-0001-8149-0483
+   affiliation: National Research University Higher School of Economics
+date: XXX
+bibliography: paper.bib
+---
+
+# Summary
+
+SciPy (pronounced "Sigh Pie") is open-source software for mathematics, science,
+and engineering. It includes modules for statistics, optimization, integration,
+linear algebra, Fourier transforms, signal and image processing, ODE solvers,
+and more. 
+
+The @SciPy library depends on @NumPy, which provides convenient and fast N-dimensional
+array manipulation. The SciPy library is built to work with NumPy arrays, and
+provides many user-friendly and efficient numerical routines such as routines
+for numerical integration and optimization. 
+
+The latest stable release of SciPy is [0.18.1](@SciPy0181), which improves on the feature
+release [0.18.0](SciPy0180). Together they contain numerous bug-fixes, improved test coverage,
+better documentation and many new features. For the complete description of the
+contents of the 0.18 series, see the [release notes](https://github.com/scipy/scipy/releases/tag/v0.18.0).
+
+# Acknowledgements
+
+We gratefull acknowledge contributions of more than four hundred people whose work
+over more than fifteen years went into previous releases of SciPy and made the
+current release possible.
+
+
+# References

--- a/joss_paper_0.18/paper.md
+++ b/joss_paper_0.18/paper.md
@@ -17,10 +17,13 @@ bibliography: paper.bib
 
 # Summary
 
-SciPy (pronounced "Sigh Pie") is open-source library for mathematics, science,
-and engineering. It includes modules for statistics, optimization, integration,
-linear algebra, Fourier transforms, signal and image processing, ODE solvers,
-and more. 
+SciPy (pronounced "Sigh Pie") is an open source library for mathematics, science,
+and engineering. It includes modules for statistics, optimization and root finding,
+fitting,  evaluation of special functions, interpolation, integration, ODE solvers,
+Fourier transforms, handling of sparse matrices, linear algebra with dense and
+sparse matrices, hierarchial clustering, signal and N-dimensional image processing,
+spatial algorithms and data structures, graph algorithms, and reading and
+writing data files in a variety of common data formats.
 
 The @SciPy library depends on @NumPy, which provides convenient and fast N-dimensional
 array manipulation. The SciPy library is built to work with NumPy arrays, and
@@ -29,8 +32,18 @@ for numerical integration and optimization.
 
 The latest stable release of SciPy is [0.18.1](@SciPy0181), which improves on the feature
 release [0.18.0](SciPy0180). Together they contain numerous bug-fixes, improved test coverage,
-better documentation, and many new features. For the complete description of the
-contents of the 0.18 series, see the [release notes](https://github.com/scipy/scipy/releases/tag/v0.18.0).
+better documentation, and many new features. 
+
+Highlights of this release include:
+
+* A new ODE solver for two-point boundary value problems, `scipy.optimize.solve_bvp`.
+* A new class, `scipy.interpolate.CubicSpline`, for cubic spline interpolation of data.
+* N-dimensional tensor product polynomials, `scipy.interpolate.NdPPoly`.
+* Spherical Voronoi diagrams, `scipy.spatial.SphericalVoronoi`.
+* Support for discrete-time linear systems, `scipy.signal.dlti`.
+
+For the complete description of the contents of the 0.18 series, see the
+[release notes](https://github.com/scipy/scipy/releases/tag/v0.18.0).
 
 # Acknowledgements
 

--- a/joss_paper_0.18/paper.md
+++ b/joss_paper_0.18/paper.md
@@ -8,6 +8,9 @@ authors:
  - name: Evgeni Burovski
    orcid: 0000-0001-8149-0483
    affiliation: National Research University Higher School of Economics
+ - name: Andrew Nelson
+   orcid: 0000-0002-4548-3558
+   affiliation: Australian Nuclear Science and Technology Organisation
 date: XXX
 bibliography: paper.bib
 ---


### PR DESCRIPTION
As discussed during the dev hangout on 14 Oct (https://docs.google.com/document/d/1srVFUvxEUOKzJBuCI8oqn17D7TYLcLIwMJKFRRD4bB0/edit?ts=57ff506a), and several off-list discussions, here's a first draft for the "abstract-paper" for submission to JOSS, http://joss.theoj.org/

Comments welcome.

Suggested procedure:

* Limit the scope by the 0.18.x series, i.e. releases 0.18.0 and 0.18.1
* Anyone who made a substantial contribution to either of these releases is invited to add themselves as an author. Here "substantial" is interpreted as anything beyond a one-line doc fix.
* Authors can either send PRs adding their names and affiliations to `paper.md`, or add this information to a special issue (to avoid a rebase mess where everyone is editing the same three lines): gh-5
* We need to pick a submission date. Here's one random date, 12 Dec 2016 (three weeks and a weekend from today).  