### PR TITLE
WIP: Add introduction & history section

### DIFF
--- a/scipy-1.0/history_notes.md
+++ b/scipy-1.0/history_notes.md
@@ -1,0 +1,85 @@
+- [Gource history graph visualization](https://www.youtube.com/watch?v=AC-wF3Tk6PM)
+- Editorials
+  - [2008](http://conference.scipy.org/proceedings/scipy2008/paper_0)
+  - [State of SciPy](http://conference.scipy.org/proceedings/scipy2008/paper_1/)
+  - [2009](http://conference.scipy.org/proceedings/scipy2009/paper_0)
+  - [2010](http://conference.scipy.org/proceedings/scipy2010/vanderwalt.html)
+  - [2011](http://conference.scipy.org/proceedings/scipy2011/vanderwalt.html)
+- [Documentation project](http://conference.scipy.org/proceedings/scipy2008/paper_5/)
+  - [Travis's initial email to list](https://mail.python.org/pipermail/numpy-discussion/2007-January/025383.html)
+  - [HOWTO_DOCUMENT, February 1 2007](https://github.com/numpy/numpy/commit/57d211f6fb8f9ef9f0afdffca4472bbad9556113#diff-4afb2c4584890cfb25a34786395f945c)
+  - [Matplotlib: Sphinx + Python plots + LaTeX](http://conference.scipy.org/proceedings/scipy2008/paper_6/)
+  - [Project announcement](https://mail.python.org/pipermail/numpy-discussion/2008-May/033863.html) 
+  - [Documentation project update](http://conference.scipy.org/proceedings/scipy2009/paper_14/full_text.pdf)
+- [Travis: slides, SciPy India 2009](https://www.slideshare.net/enthought/scipy-india-2009)
+- [Travis: SciPy history, SciPy Tokyo 2012](https://www.slideshare.net/shoheihido/sci-pyhistory)
+- [Travis updates NumPy documentation format after sprint](https://github.com/numpy/numpy/commit/70d815d4a5f4c5b3aab03983375903123213478a#diff-4afb2c4584890cfb25a34786395f945c)
+- [Jarrod CiSE: Python for Scientists and Engineers](https://escholarship.org/content/qt93s2v2s7/qt93s2v2s7.pdf)
+- [Old SciPy homepage: history of SciPy](https://scipy.github.io/old-wiki/pages/History_of_SciPy.html)
+- [SciPy 1.0 release notes: history and perspectives](https://docs.scipy.org/doc/scipy/reference/release.1.0.0.html#id3)
+- Scikits
+  - [SciPy documentation description](https://www.scipy.org/scikits.html)
+  - [Earliest mention found so far—keep searching](https://mail.python.org/pipermail/scipy-dev/2006-November/006315.html)
+
+Jarrod wrote:
+
+> Sometime near the end of 2004, Matthew Brett, JB Poline, and I
+> started discussing the state of neuroimaging analysis software.  I
+> got a small grant (~10K) to organize and plan for a large,
+> multi-institute grant.  We had decide to try and put together a
+> package written in Python and developed collaboratively by multiple
+> labs.  I reached out to John Hunter (as he was working in
+> neuroimaging at the time and had developed a new plotting library
+> that looked promising).  John suggested we include Fernando Perez in
+> our discussions.  We also invited a number of neuroimaging experts.
+>
+> As our meeting was approaching, the following email appeared on the
+> numpy mailing list:
+>  http://mail.scipy.org/pipermail/numpy-discussion/2005-February/003974.html
+>
+> As the result of this discussion would potentially have a large
+> impact on our future neuroimaging package, we decided to extend an
+> invitation to Travis and Perry.  We used some of the seed money to
+> fly them out (my memory is that we put folks up in houses, but we
+> may have given Travis and Perry hotel rooms).
+>
+> We had two main meeting rooms.  In one room, we discussed plans for
+> the neuroimaging package.  In the other, Travis and Perry spent 1-2
+> days focused almost exclusively on numeric/numarray/(numpy).  At the
+> end of each day, Travis and Perry reported back on their discussions
+> (and we discussed the ideas in more detail over lunch and dinner).
+> I also think that Fernando and John may have joined them for some of
+> the formal discussion.  Travis and Perry also visited with Guido on
+> the last day to discuss how/whether to try and include a
+> multidimensional array object in Python.
+>
+> Here are a series of emails, which resulted from the Berkeley meeting
+> (you may wish to peruse the subsequent threads):
+>
+> http://mail.scipy.org/pipermail/scipy-dev/2005-March/002887.html
+> http://mail.scipy.org/pipermail/scipy-dev/2005-March/002903.html
+> http://mail.scipy.org/pipermail/scipy-dev/2005-March/002909.html
+>
+> The next couple of years saw steady progress.  Here is another meeting
+> where I think major structural progress was made:
+> http://mail.scipy.org/pipermail/numpy-discussion/2007-December/030327.html
+>
+> Here are a couple of other background emails, which might be
+> interesting/useful:
+> http://mail.scipy.org/pipermail/numpy-discussion/2004-January/002645.html
+> http://mail.scipy.org/pipermail/numpy-discussion/2005-January/016229.html
+> http://mail.scipy.org/pipermail/numpy-discussion/2005-January/003908.html
+> http://mail.scipy.org/pipermail/numpy-discussion/2005-January/003922.html
+> http://mail.scipy.org/pipermail/numpy-discussion/2005-March/004424.html
+> http://mail.scipy.org/pipermail/scipy-dev/2005-December/004641.html
+> http://mail.scipy.org/pipermail/scipy-dev/2006-January/004806.html
+> http://mail.scipy.org/pipermail/numpy-discussion/2006-October/011185.html
+>
+> Best regards,
+> Jarrod
+>
+> PS.  I've been thinking for years about writing up a history (paper
+> length) of NumPy/SciPy/etc.  I've collected some notes, but never
+> put them into shape.  Would you be interested in working on
+> something like this with me? If you are interested, please let me
+> know.


### PR DESCRIPTION
Jarrod and I are happy to take on the introduction / history section.

[Suggested sections are](https://github.com/scipy/scipy-articles/issues/9#issue-294246802):
- History
- Project goals / scope of library
- Current status (maturity, users)

**Timeline:**  We will submit a full draft in September.

So far we've added some personal notes on SciPy's history.  We will draft an initial version of the project goals / status, and ask for feedback from other contributors to ensure our understanding is not out of date.

In the mean time, anyone who has additional information about SciPy history, or wants to add feedback & notes on current project goals, status, etc. should please feel free to do so below.
