### PR TITLE
Drafted a short governance section

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -122,18 +122,50 @@ LowLevelCallable
 
 \textbf{Governance}
 
-SciPy adopted an official Governance Document on August 3, 2017 (see PR\#6953). In summary,
-we have a Benevolant Dictator for Life (BDFL) in Pauli Virtanen, and a (currently) 18
-member Steering Council chaired by Ralf Gommers that i.e., decides on who gets commit rights.
+SciPy adopted an official Governance Document on August 3,
+2017\cite{SciPyProjectGovernance}.
+We have a Benevolant Dictator for Life (BDFL), Pauli Virtanen, leading the
+project, following a detailed discussion of the governance model with the
+community on the mailing list.  In practice, the overruling authority of the BDFL
+is anticipated to be used only when the Steering Council cannot agree on a matter.
+The BDFL is expected to consider any strong indications that they should step down;
+although the BDFL may appoint a successor it is generally expected that the Steering
+Council will be consulted on the matter.
 
-SciPy adopted an official Code of Conduct on October 24, 2017 (see PR\#7963), drawing
-inspiration from the Apache Foundation Code of Conduct, the Contributor Covenant,
-the Jupyter Code of Conduct, and the Open Source Guides - Code of Conduct. In short,
+The (currently) 18 member Steering Council is chaired by Ralf Gommers and performs a number of
+tasks including nominating and voting on new Council Members, and actively
+contributing to the progress of the project (could be code review but also
+outreach activities, etc.). Generally, 1 year of sustained and substantial
+contributions (not restricted to source code contributions) that improve
+the project are the prerequiste for nomination of new Council Members. Council
+Members do not get special treatment for the vast majority of the day to day
+project activities (code submission / review), though it is anticipated that their
+experience with the project will serve as helpful guidance in many matters.
+Council Members have commit rights to the project, but will typically only
+incorporate changes when there are no substantive community objections. The
+Chair of the Steering Council is responsible for starting more formal
+technical reviews of the direction of the project, ensuring that the
+composition of the Council remains current, and communicating / summarizing
+any Council activities performed privately to the broader community. We also
+describe in some detail how institutional partners may contribute to the
+project, but no financial weight from grants or other sources
+may be leveraged to circumvent or overrule the technical direction of the
+project decided upon by the Steering Committee. The Chair does not have
+a fixed term, but is nominated by the Steering Committee and is expected
+to yield to substantive claims that stepping down is the appropriate action.
+
+SciPy adopted an official Code of Conduct on October 24, 2017
+\cite{SciPyCodeOfConduct}, drawing
+inspiration from the Apache Foundation Code of
+Conduct\cite{ApacheCodeOfConduct}, the Contributor Covenant
+\cite{ContributorConvenant},
+the Jupyter Code of Conduct \cite{Jupyter_COC}, and the Open Source Guides -
+Code of Conduct\cite{OSG_COC}. In short,
 we stated five specific guidelines: \emph{be open} (to anyone participating in our community),
 \emph{be empathetic and patient} (in resolving conflicts), \emph{be collaborative} (we depend
 on each other to build up the tools in the library), \emph{be inquisitive} (identifying issues
 early on can be helpful to everyone), and \emph{be careful with wording} (do not harass or exclude).
-We outline a broad diversity inclusion statement, and provide
+We outlined a broad diversity inclusion statement, and provide
 instructions for contacting the three members of our Code of Conduct Committee or an
 external representative on the NumFOCUS Board of Directors.
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -132,8 +132,8 @@ the Jupyter Code of Conduct, and the Open Source Guides - Code of Conduct. In sh
 we stated five specific guidelines: \emph{be open} (to anyone participating in our community),
 \emph{be empathetic and patient} (in resolving conflicts), \emph{be collaborative} (we depend
 on each other to build up the tools in the library), \emph{be inquisitive} (identifying issues
-early on can be helpful to everyone), and \emph{be careful with wording} (no harassment or
-exclusionary behavior). We outline a broad diversity inclusion statement, and provide
+early on can be helpful to everyone), and \emph{be careful with wording} (do not harass or exclude).
+We outline a broad diversity inclusion statement, and provide
 instructions for contacting the three members of our Code of Conduct Committee or an
 external representative on the NumFOCUS Board of Directors.
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -122,6 +122,21 @@ LowLevelCallable
 
 \textbf{Governance}
 
+SciPy adopted an official Governance Document on August 3, 2017 (see PR\#6953). In summary,
+we have a Benevolant Dictator for Life (BDFL) in Pauli Virtanen, and a (currently) 18
+member Steering Council chaired by Ralf Gommers that i.e., decides on who gets commit rights.
+
+SciPy adopted an official Code of Conduct on October 24, 2017 (see PR\#7963), drawing
+inspiration from the Apache Foundation Code of Conduct, the Contributor Covenant,
+the Jupyter Code of Conduct, and the Open Source Guides - Code of Conduct. In short,
+we stated five specific guidelines: \emph{be open} (to anyone participating in our community),
+\emph{be empathetic and patient} (in resolving conflicts), \emph{be collaborative} (we depend
+on each other to build up the tools in the library), \emph{be inquisitive} (identifying issues
+early on can be helpful to everyone), and \emph{be careful with wording} (no harassment or
+exclusionary behavior). We outline a broad diversity inclusion statement, and provide
+instructions for contacting the three members of our Code of Conduct Committee or an
+external representative on the NumFOCUS Board of Directors.
+
 \textbf{Roadmap}
 
 \textbf{Community beyond the SciPy library}

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -390,7 +390,7 @@
 }
 
 @online{SciPyProjectGovernance,
-author = {The SciPy Community},
+author = {{The SciPy Community}},
 title = {{SciPy} Project Governance},
 year = 2017,
 url = {https://docs.scipy.org/doc/scipy/reference/dev/governance/governance.html},
@@ -398,7 +398,7 @@ urldate = {2018-06-01}
 }
 
 @online{SciPyCodeOfConduct,
-author = {The SciPy Community},
+author = {{The SciPy Community}},
 title = {{SciPy} Code of Conduct},
 year = 2017,
 url = {https://docs.scipy.org/doc/scipy/reference/dev/conduct/code_of_conduct.html},
@@ -406,7 +406,7 @@ urldate = {2018-06-01}
 }
 
 @online{ApacheCodeOfConduct,
-author = {Apache Software Foundation},
+author = {{Apache Software Foundation}},
 title = {Apache Software Foundation Code of Conduct},
 year = 2018,
 url = {https://www.apache.org/foundation/policies/conduct.html},

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -388,3 +388,52 @@
   title= "{CODATA} 2014 recommended values of the fundamental physical constants",
   year="2014"
 }
+
+@online{SciPyProjectGovernance,
+author = {The SciPy Community},
+title = {{SciPy} Project Governance},
+year = 2017,
+url = {https://docs.scipy.org/doc/scipy/reference/dev/governance/governance.html},
+urldate = {2018-06-01}
+}
+
+@online{SciPyCodeOfConduct,
+author = {The SciPy Community},
+title = {{SciPy} Code of Conduct},
+year = 2017,
+url = {https://docs.scipy.org/doc/scipy/reference/dev/conduct/code_of_conduct.html},
+urldate = {2018-06-01}
+}
+
+@online{ApacheCodeOfConduct,
+author = {Apache Software Foundation},
+title = {Apache Software Foundation Code of Conduct},
+year = 2018,
+url = {https://www.apache.org/foundation/policies/conduct.html},
+urldate = {2018-06-01}
+}
+
+@online{ContributorConvenant,
+author = {Ada Ehmke, Coraline},
+title = {A Code of Conduct for Open Source Projects},
+year = 2014,
+url = {https://www.contributor-covenant.org/},
+urldate = {2018-06-01}
+}
+
+@online{Jupyter_COC,
+author = {Perez, Fernando and Panda, Yuvi and Ivanov, Paul and Grout, Jason },
+title = {Project {J}upyter Code of Conduct},
+year = 2017,
+url = {https://github.com/jupyter/governance/blob/master/conduct/code_of_conduct.md},
+urldate = {2018-06-01}
+}
+
+@online{OSG_COC,
+author = {Eghbal, Nadia and Keepers, Brandon and Wills, Stephanie and
+	Linksvayer, Mike},
+title = {Open Source Guides: Your Code of Conduct},
+year = 2018,
+url = {https://opensource.guide/code-of-conduct/},
+urldate = {2018-06-01}
+}


### PR DESCRIPTION
The recently-adopted Governance and Code of Conduct Documents are mentioned in the proposed manuscript outline; I've tried to draft a summary of the recently-adopted docs in this PR. I think @rgommers was slotted to draft this subsection, so please do criticize here! Just trying to keep things moving.

Maybe we can cite the respective documents a bit more "formally" than I have at the moment (I just used the pull request numbers for now) & perhaps the same for the Codes of Conduct from other communities that inspired us (only mentioned by popular name at the moment).