### PR TITLE
ENH: add some authors and a title for manuscript

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -14,7 +14,7 @@
 \newcommand{\xmark}{\ding{55}}%
 
 
-\title {SciPy 1.0 - Fundamental Algorithms for Scientific Computing in Python}
+\title{SciPy 1.0---Fundamental Algorithms for Scientific Computing in Python}
 
 \author[1]{Pauli Virtanen}
 \author[2,*]{Ralf Gommers}

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -33,12 +33,11 @@
 \author[16]{Josh Wilson}
 \author[17]{Matthew Brett}
 \author[18]{Nikolay Mayorov}
-\author[19]{Tyler Reddy}
-\author[20]{Warren Weckesser}
-\author[21]{Matt Haberland}
-\author[22]{Scott Sievert}
-\author[23]{Yu Feng}
-\author[24]{Antonio Horta Ribeiro}
+\author[19]{Warren Weckesser}
+\author[20]{Matt Haberland}
+\author[21]{Scott Sievert}
+\author[22]{Yu Feng}
+\author[23]{Antonio Horta Ribeiro}
 
 \affil[1]{Affiliation, department, city, postcode, country}
 \affil[2]{Affiliation, department, city, postcode, country}
@@ -67,7 +66,6 @@
 \affil[21]{Affiliation, department, city, postcode, country}
 \affil[22]{Affiliation, department, city, postcode, country}
 \affil[23]{Affiliation, department, city, postcode, country}
-\affil[24]{Affiliation, department, city, postcode, country}
 
 \affil[*]{ralf.gommers@gmail.com}
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -14,14 +14,60 @@
 \newcommand{\xmark}{\ding{55}}%
 
 
-\title {SciPy - some descriptive title here}
+\title {SciPy 1.0 - A Mature Library for Scientific Computing in Python}
 
 \author[1]{Pauli Virtanen}
 \author[2,*]{Ralf Gommers}
-\author[3]{TODO}
+\author[3,4]{Tyler Reddy}
+\author[5]{Anne Archibald}
+\author[6]{Andrew Nelson}
+\author[7]{Charles Harris}
+\author[8]{CJ Carey}
+\author[9]{Denis Laxalde}
+\author[10]{Eric Larson}
+\author[11]{Eric Moore}
+\author[12]{Eric Quintero}
+\author[13]{Evgeni Burovski}
+\author[14]{Jaime Fernández del Río}
+\author[15]{Josef Perktold}
+\author[16]{Josh Wilson}
+\author[17]{Matthew Brett}
+\author[18]{Nikolay Mayorov}
+\author[19]{Tyler Reddy}
+\author[20]{Warren Weckesser}
+\author[21]{Matt Haberland}
+\author[22]{Scott Sievert}
+\author[23]{Yu Feng}
+\author[24]{Antonio Horta Ribeiro}
+
 \affil[1]{Affiliation, department, city, postcode, country}
 \affil[2]{Affiliation, department, city, postcode, country}
 \affil[2]{Affiliation, department, city, postcode, country}
+\affil[3]{UC Berkeley Institute for Data Science,
+          Berkeley, CA, 94720, USA}
+\affil[4]{Los Alamos National Laboratory,
+	  Theoretical Division 6,
+          Los Alamos, NM, 87545, USA}
+\affil[5]{Affiliation, department, city, postcode, country}
+\affil[6]{Affiliation, department, city, postcode, country}
+\affil[7]{Affiliation, department, city, postcode, country}
+\affil[8]{Affiliation, department, city, postcode, country}
+\affil[9]{Affiliation, department, city, postcode, country}
+\affil[10]{Affiliation, department, city, postcode, country}
+\affil[11]{Affiliation, department, city, postcode, country}
+\affil[12]{Affiliation, department, city, postcode, country}
+\affil[13]{Affiliation, department, city, postcode, country}
+\affil[14]{Affiliation, department, city, postcode, country}
+\affil[15]{Affiliation, department, city, postcode, country}
+\affil[16]{Affiliation, department, city, postcode, country}
+\affil[17]{Affiliation, department, city, postcode, country}
+\affil[18]{Affiliation, department, city, postcode, country}
+\affil[19]{Affiliation, department, city, postcode, country}
+\affil[20]{Affiliation, department, city, postcode, country}
+\affil[21]{Affiliation, department, city, postcode, country}
+\affil[22]{Affiliation, department, city, postcode, country}
+\affil[23]{Affiliation, department, city, postcode, country}
+\affil[24]{Affiliation, department, city, postcode, country}
 
 \affil[*]{ralf.gommers@gmail.com}
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -14,7 +14,7 @@
 \newcommand{\xmark}{\ding{55}}%
 
 
-\title {SciPy 1.0 - A Mature Library for Scientific Computing in Python}
+\title {SciPy 1.0 - Fundamental Algorithms for Scientific Computing in Python}
 
 \author[1]{Pauli Virtanen}
 \author[2,*]{Ralf Gommers}


### PR DESCRIPTION
I've drafted a title for the manuscript and added the steering committee members to the author list; I've also added the contributors to the paper so far if they weren't already included in the latter list. 

This somewhat circumvents the originally-described detailed procedure for authorship assignments, but hopefully isn't too controversial and helps us continue to move forward. Nothing in particular is meant by the current ordering of authors; I suppose people should start adding themselves / their affiliations when they next open a PR etc.