### PR TITLE
Clarify / add some references for Impact Now subsection

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -207,11 +207,13 @@ accepted into the code base (GitHub page data).
 % SciPy stuff from njs blog: https://docs.google.com/spreadsheets/d/1lOLvSF0up4eZyv2ugZi-TM_GIs3gPCkGNIDKXS1Y3w4/edit#gid=406031940
 From the user side, there have been at least 15 million downloads
 of the SciPy manylinux wheels between the start of 2016 and May of 2018
-(njs blog). The recommended manuscript for citing SciPy,
-published online 17 years ago, has been cited $>3000$
+(njs blog). The recommended source for citing SciPy is simply a reference
+to the website / library itself\cite{SciPylib}, and has been cited $>3000$
 times. Some of the most prominent citing articles include the IPython
-publication, a heavily-cited Nature Biotechnology article, a dark
-matter annihlitation study in the field of cosmology, and many of the
+publication\cite{PER-GRA:2007}, a heavily-cited Nature Biotechnology
+article\cite{pmid17287757}, a dark
+matter annihilitation study in the field of
+cosmology\cite{1475-7516-2012-08-007}, and many of the
 other major downstream software libraries in the Python scientific
 computing stack.
 

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -437,3 +437,48 @@ year = 2018,
 url = {https://opensource.guide/code-of-conduct/},
 urldate = {2018-06-01}
 }
+
+@Misc{SciPylib,
+  author = {Eric Jones and Travis Oliphant and Pearu Peterson and others},
+  title =  {{SciPy}: Open source scientific tools for {Python}},
+  year =   {2001--},
+  url = "http://www.scipy.org/",
+  note = {[Online; accessed 2018-06-28]}
+}
+
+@Article{PER-GRA:2007,
+  Author    = {P\'erez, Fernando and Granger, Brian E.},
+  Title     = {{IP}ython: a System for Interactive Scientific Computing},
+  Journal   = {Computing in Science and Engineering},
+  Volume    = {9},
+  Number    = {3},
+  Pages     = {21--29},
+  month     = may,
+  year      = 2007,
+  url       = "http://ipython.org",
+  ISSN      = "1521-9615",
+  doi       = {10.1109/MCSE.2007.53},
+  publisher = {IEEE Computer Society},
+}
+
+@Article{pmid17287757,
+   Author="Keiser, M. J.  and Roth, B. L.  and Armbruster, B. N.  and Ernsberger, P.  and Irwin, J. J.  and Shoichet, B. K. ",
+   Title="{{R}elating protein pharmacology by ligand chemistry}",
+   Journal="Nat. Biotechnol.",
+   Year="2007",
+   Volume="25",
+   Number="2",
+   Pages="197--206",
+   Month="Feb"
+}
+
+@article{1475-7516-2012-08-007,
+  author={Christoph Weniger},
+  title={A tentative gamma-ray line from Dark Matter annihilation at the Fermi Large Area Telescope},
+  journal={Journal of Cosmology and Astroparticle Physics},
+  volume={2012},
+  number={08},
+  pages={007},
+  url={http://stacks.iop.org/1475-7516/2012/i=08/a=007},
+  year={2012},
+}


### PR DESCRIPTION
Attempt to address @rgommers [comment](https://github.com/scipy/scipy-articles/pull/28#discussion_r198720893) for this subsection re: SciPy not currently having a journal publication & also add proper references for some of the prominent journal articles that cite usage of the SciPy library.