### PR TITLE
Add section on stats distributions

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -264,28 +264,29 @@ from a Cython module using \texttt{scipy.LowLevelCallable.from\_cython}.
 
 \subsection*{Statistical distributions}
 Version 1.0 of SciPy saw the addition of the energy distance algorithm in
-\texttt{scipy.stats.energy\_distance}. Energy distance is used in a varity of applications ranging
-from genetic analysis to multivariate independence. We also added the
+\texttt{scipy.stats.energy\_distance}. Energy distance is used in a variety
+of applications ranging from genetic analysis\cite{Hu2008DetectingIC} to 
+multivariate independence\cite{szekely2009}. We also added the
 first Wasserstein distance algorithm to the library in
 \texttt{scipy.stats.wasserstein\_distance}. The Wasserstein distance is often
-used in color digital image analysis.
+used in color digital image analysis \cite{192468}.
 
-We now also provide the cumulative distribution function of the multivariate
+We now provide the cumulative distribution function of the multivariate
 normal distribution, \\\texttt{scipy.stats.multivariate\_normal}, via the newly
-associated \texttt{logcdf} and \texttt{cdf} methods.
+associated \texttt{logcdf} and \texttt{cdf} methods. Other recent distributions 
+added to \texttt{scipy.stats} include the Argus distribution
+in \texttt{scipy.stats.argus} (used in particle physics\cite{ALBRECHT1990278}), a histogram-based
+distribution in \texttt{scipy.stats.rv\_histogram}, the multinomial
+distribution in \texttt{scipy.stats.multinomial} (used, for example, in natural
+language processing\cite{Griffiths5228}), the Burr type XII distribution in
+\texttt{scipy.stats.burr12}, the skew normal distribution 
+in \texttt{scipy.stats.skewnorm}, the trapezoidal distribution in 
+\texttt{scipy.stats.trapz}, and the matrix normal distribution
+in \texttt{scipy.stats.matrix\_normal}.
 
-Other recent additions to \texttt{scipy.stats} include the Argus distribution
-in \texttt{scipy.stats.argus} (used in particle physics), a class for
-generating a distribution from a histogram in
-\texttt{scipy.stats.rv\_histogram}, an implementation of the multinomial
-distribution in \texttt{scipy.stats.multinomial} (used for example in natural
-language processing), a weighted Kendall's tau statistic algorithm in
-\texttt{scipy.stats.weightedtau}, interquantile range handling in
-\texttt{scipy.stats.iqr}, the Burr type XII distribution is available in
-\texttt{scipy.stats.burr12}, the skew normal distribution has been implemented 
-as \texttt{scipy.stats.skewnorm}, a trepzoidal continuous random variable
-has been added in \texttt{scipy.stats.trapz}, and the matrix normal distribution
-is now available in \texttt{scipy.stats.matrix\_normal}. 
+There's also a new weighted Kendall's tau statistic algorithm in
+\texttt{scipy.stats.weightedtau}, and interquantile range handling in
+\texttt{scipy.stats.iqr} 
 
 From a design standpoint, many functions in \texttt{scipy.stats} now support
 a \texttt{nan\_policy} keyword to allow user-level control over the algorithmic

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -263,14 +263,16 @@ from a Cython module using \texttt{scipy.LowLevelCallable.from\_cython}.
 
 
 \subsection*{Statistical distributions}
-The \texttt{scipy.stats} module provides a framework to implement probability
-distributions.  Given an expression for a probability distribution function (pdf),
+The \texttt{scipy.stats} module provides provides more than 100 probability
+distributions and a framework to implement additional distributions. Given
+an expression for a probability distribution function (pdf),
 the framework will calculate moments, cumulative distribution function (cdf),
 differential entropy, and more. Those properties are calculated based on
-generic code, e.g., numerical integration of the pdf to obtain the cdf. In cases
-where that generic code does not provide sufficient accuracy, it is replaced
-by an implemented specific to the distribution.
-The distributions framework also allows the user to draw random
+generic code, e.g., numerical integration of the pdf to obtain the cdf.
+Where possible, the generic code is replaced by explicit formulas or more
+accurate or efficient implementations. For example, most distributions have
+an explicit formula for the cdf, so it is used instead of integrating the
+pdf. The distributions framework also allows the user to draw random
 variates from the distribution. Drawing random variates now accepts a \texttt{random\_state}
 parameter, which is either a \texttt{numpy.random.RandomState} object or an
 integer used to generate such an object, to provide fine-grained user-level

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -263,24 +263,26 @@ from a Cython module using \texttt{scipy.LowLevelCallable.from\_cython}.
 
 
 \subsection*{Statistical distributions}
-
-We now provide the cumulative distribution function (using the Fortran code by
-Alan Genz) of the multivariate normal distribution, \\\texttt{scipy.stats.multivariate\_normal},
-via the newly associated \texttt{logcdf} and \texttt{cdf} methods. Other key recent distributions 
-added to \texttt{scipy.stats} include the histogram-based
+The \texttt{scipy.stats} module provides a framework to implement probability
+distributions.  Given an expression for a probability distribution function (pdf),
+the framework will calculate moments, cumulative distribution function (cdf),
+differential entropy, and more. Those properties are calculated based on
+generic code, e.g., numerical integration of the pdf to obtain the cdf. In cases
+where that generic code does not provide sufficient accuracy, it is replaced
+by an implemented specific to the distribution.
+The distributions framework also allows the user to draw random
+variates from the distribution. Drawing random variates now accepts a \texttt{random\_state}
+parameter, which is either a \texttt{numpy.random.RandomState} object or an
+integer used to generate such an object, to provide fine-grained user-level
+control over the random state of a workflow.
+Currently about 80 continuous univariate distributions, 12 discrete univariate
+distributions and 10 multivariate distributions are implemented.
+Key recent distributions added to \texttt{scipy.stats} include the histogram-based
 distribution in \texttt{scipy.stats.rv\_histogram} and the multinomial
 distribution in \texttt{scipy.stats.multinomial} (used, for example, in natural
 language processing\cite{Griffiths5228}). \texttt{multinomial} is the first and so 
 far the only multivariate discrete distribution available in SciPy.
 
-From a design standpoint, many functions in \texttt{scipy.stats} now support
-a \texttt{nan\_policy} keyword to allow user-level control over the algorithmic
-decision to propagate, omit, or raise an error in the case that \texttt{NaN}
-values are encountered. Much of the functionality offered by
-\texttt{scipy.stats} for drawing random variates now accepts a
-\texttt{random\_state} parameter, which is either a \texttt{numpy.random.RandomState}
-object or an integer used to generate such an object, to provide fine-grained
-user-level control over the random state of a workflow.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection*{Polynomial interpolators}

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -263,35 +263,24 @@ from a Cython module using \texttt{scipy.LowLevelCallable.from\_cython}.
 
 
 \subsection*{Statistical distributions}
-Version 1.0 of SciPy saw the addition of the energy distance algorithm in
-\texttt{scipy.stats.energy\_distance}. Energy distance is used in a variety
-of applications ranging from genetic analysis\cite{Hu2008DetectingIC} to 
-multivariate independence\cite{szekely2009}. We also added the
-first Wasserstein distance algorithm to the library in
-\texttt{scipy.stats.wasserstein\_distance}. The Wasserstein distance is often
-used in color digital image analysis \cite{192468}.
 
-We now provide the cumulative distribution function of the multivariate
-normal distribution, \\\texttt{scipy.stats.multivariate\_normal}, via the newly
-associated \texttt{logcdf} and \texttt{cdf} methods. Other recent distributions 
-added to \texttt{scipy.stats} include the Argus distribution
-in \texttt{scipy.stats.argus} (used in particle physics\cite{ALBRECHT1990278}), a histogram-based
-distribution in \texttt{scipy.stats.rv\_histogram}, the multinomial
+We now provide the cumulative distribution function (using the Fortran code by
+Alan Genz) of the multivariate normal distribution, \\\texttt{scipy.stats.multivariate\_normal},
+via the newly associated \texttt{logcdf} and \texttt{cdf} methods. Other key recent distributions 
+added to \texttt{scipy.stats} include the histogram-based
+distribution in \texttt{scipy.stats.rv\_histogram} and the multinomial
 distribution in \texttt{scipy.stats.multinomial} (used, for example, in natural
-language processing\cite{Griffiths5228}), the Burr type XII distribution in
-\texttt{scipy.stats.burr12}, the skew normal distribution 
-in \texttt{scipy.stats.skewnorm}, the trapezoidal distribution in 
-\texttt{scipy.stats.trapz}, and the matrix normal distribution
-in \texttt{scipy.stats.matrix\_normal}.
-
-There's also a new weighted Kendall's tau statistic algorithm in
-\texttt{scipy.stats.weightedtau}, and interquantile range handling in
-\texttt{scipy.stats.iqr} 
+language processing\cite{Griffiths5228}). \texttt{multinomial} is the first and so 
+far the only multivariate discrete distribution available in SciPy.
 
 From a design standpoint, many functions in \texttt{scipy.stats} now support
 a \texttt{nan\_policy} keyword to allow user-level control over the algorithmic
 decision to propagate, omit, or raise an error in the case that \texttt{NaN}
-values are encountered.
+values are encountered. Much of the functionality offered by
+\texttt{scipy.stats} for drawing random variates now accepts a
+\texttt{random\_state} parameter, which is either a \texttt{numpy.random.RandomState}
+object or an integer used to generate such an object, to provide fine-grained
+user-level control over the random state of a workflow.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection*{Polynomial interpolators}

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -263,6 +263,34 @@ from a Cython module using \texttt{scipy.LowLevelCallable.from\_cython}.
 
 
 \subsection*{Statistical distributions}
+Version 1.0 of SciPy saw the addition of the energy distance algorithm in
+\texttt{scipy.stats.energy\_distance}. Energy distance is used in a varity of applications ranging
+from genetic analysis to multivariate independence. We also added the
+first Wasserstein distance algorithm to the library in
+\texttt{scipy.stats.wasserstein\_distance}. The Wasserstein distance is often
+used in color digital image analysis.
+
+We now also provide the cumulative distribution function of the multivariate
+normal distribution, \\\texttt{scipy.stats.multivariate\_normal}, via the newly
+associated \texttt{logcdf} and \texttt{cdf} methods.
+
+Other recent additions to \texttt{scipy.stats} include the Argus distribution
+in \texttt{scipy.stats.argus} (used in particle physics), a class for
+generating a distribution from a histogram in
+\texttt{scipy.stats.rv\_histogram}, an implementation of the multinomial
+distribution in \texttt{scipy.stats.multinomial} (used for example in natural
+language processing), a weighted Kendall's tau statistic algorithm in
+\texttt{scipy.stats.weightedtau}, interquantile range handling in
+\texttt{scipy.stats.iqr}, the Burr type XII distribution is available in
+\texttt{scipy.stats.burr12}, the skew normal distribution has been implemented 
+as \texttt{scipy.stats.skewnorm}, a trepzoidal continuous random variable
+has been added in \texttt{scipy.stats.trapz}, and the matrix normal distribution
+is now available in \texttt{scipy.stats.matrix\_normal}. 
+
+From a design standpoint, many functions in \texttt{scipy.stats} now support
+a \texttt{nan\_policy} keyword to allow user-level control over the algorithmic
+decision to propagate, omit, or raise an error in the case that \texttt{NaN}
+values are encountered.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection*{Polynomial interpolators}

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -759,6 +759,7 @@ urldate = {2018-07-06}
  publisher = {ACM},
  address = {New York, NY, USA},
  keywords = {LLVM, Python, compiler},
+}
 
 @article{Hu2008DetectingIC,
   title={Detecting intergene correlation changes in microarray analysis: a new approach to gene selection},

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -759,6 +759,70 @@ urldate = {2018-07-06}
  publisher = {ACM},
  address = {New York, NY, USA},
  keywords = {LLVM, Python, compiler},
+
+@article{Hu2008DetectingIC,
+  title={Detecting intergene correlation changes in microarray analysis: a new approach to gene selection},
+  author={Rui Hu and Xing Qiu and Galina V. Glazko and Lev Klebanov and Andrei Yakovlev},
+  journal={BMC Bioinformatics},
+  year={2008},
+  volume={10},
+  pages={20 - 20}
+}
+
+@article{szekely2009,
+author = "Székely, Gábor J. and Rizzo, Maria L.",
+doi = "10.1214/09-AOAS312",
+fjournal = "The Annals of Applied Statistics",
+journal = "Ann. Appl. Stat.",
+month = "12",
+number = "4",
+pages = "1236--1265",
+publisher = "The Institute of Mathematical Statistics",
+title = "Brownian distance covariance",
+url = "https://doi.org/10.1214/09-AOAS312",
+volume = "3",
+year = "2009"
+}
+
+@ARTICLE{192468,
+author={S. Peleg and M. Werman and H. Rom},
+journal={IEEE Transactions on Pattern Analysis and Machine Intelligence},
+title={A unified approach to the change of resolution: space and gray-level},
+year={1989},
+volume={11},
+number={7},
+pages={739-742},
+keywords={computer vision;graph theory;computer vision;graph theory;gray-level requantization;gray-tone image;half-tone image;resolution change;spatial resampling;Application software;Computer graphics;Computer vision;Image analysis;Image coding;Image resolution;Read only memory;Signal resolution;Spatial resolution;Tail},
+doi={10.1109/34.192468},
+ISSN={0162-8828},
+month={Jul},}
+
+@article{ALBRECHT1990278,
+title = "Search for hadronic b->u decays",
+journal = "Physics Letters B",
+volume = "241",
+number = "2",
+pages = "278 - 282",
+year = "1990",
+issn = "0370-2693",
+doi = "https://doi.org/10.1016/0370-2693(90)91293-K",
+url = "http://www.sciencedirect.com/science/article/pii/037026939091293K",
+author = "H. Albrecht and R. GlÃ€ser and G. Harder and A. KrÃŒger and A.W. Nilsson and A. Nippe and T. Oest and M. Reidenbach and M. SchÃ€fer and W. Schmidt-Parzefall and H. SchrÃ¶der and H.D. Schulz and F. Sefkow and R. Wurth and R.D. Appuhn and A. Drescher and C. Hast and G. Herrera and H. Kolanoski and A. Lange and A. Lindner and R. Mankel and H. Scheck and G. Schweda and B. Spaan and A. Walther and D. Wegener and M. Paulini and K. Reim and U. Volland and H. Wegener and W. Funk and J. Stiewe and S. Werner and S. Ball and J.C. Gabriel and C. Geyer and A. HÃ¶lscher and W. Hofmann and B. Holzer and S. Khan and J. Spengler and C.E.K. Charlesworth and K.W. Edwards and W.R. Frisken and H. Kapitza and P. Krieger and R. Kutschke and D.B. Macfarlene and K.W. McLean and R.S. Orr and J.A. Parsons and P.M. Patel and J.D. Prentice and S.C. Seidel and J.D. Swain and G. Tsipolitis and K. Tzamariudaki and T.-S. Yoon and T. Ruf and S. Schael and K.R. Schubert and K. Strahl and R. Waldi and S. Weseler and B. BoÅ¡tjanÄiÄ and G. Kernel and P. KriÅŸan and E. KriÅŸniÄ and H.I. CronstrÃ¶m and L. JÃ¶nsson and A. Babaev and M. Danilo and B. Fominykh and A. Golutvin and I. Gorelov and V. Lubimov and A. Rostovtsev and A. Semenov and S. Semenov and V. Shevchenko and V. Soloshenko and V. Tchistilin and I. Tichomirov and Yu. Zaitsev and R. Childers and C.W. Darden"
+}
+
+@article{Griffiths5228,
+	author = {Griffiths, Thomas L. and Steyvers, Mark},
+	title = {Finding scientific topics},
+	volume = {101},
+	number = {suppl 1},
+	pages = {5228--5235},
+	year = {2004},
+	doi = {10.1073/pnas.0307752101},
+	publisher = {National Academy of Sciences},
+	issn = {0027-8424},
+	URL = {http://www.pnas.org/content/101/suppl_1/5228},
+	eprint = {http://www.pnas.org/content/101/suppl_1/5228.full.pdf},
+	journal = {Proceedings of the National Academy of Sciences}
 }
 
 @article{Sproull:1991:RNS:3118219.3118331,

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -761,56 +761,6 @@ urldate = {2018-07-06}
  keywords = {LLVM, Python, compiler},
 }
 
-@article{Hu2008DetectingIC,
-  title={Detecting intergene correlation changes in microarray analysis: a new approach to gene selection},
-  author={Rui Hu and Xing Qiu and Galina V. Glazko and Lev Klebanov and Andrei Yakovlev},
-  journal={BMC Bioinformatics},
-  year={2008},
-  volume={10},
-  pages={20 - 20}
-}
-
-@article{szekely2009,
-author = "Székely, Gábor J. and Rizzo, Maria L.",
-doi = "10.1214/09-AOAS312",
-fjournal = "The Annals of Applied Statistics",
-journal = "Ann. Appl. Stat.",
-month = "12",
-number = "4",
-pages = "1236--1265",
-publisher = "The Institute of Mathematical Statistics",
-title = "Brownian distance covariance",
-url = "https://doi.org/10.1214/09-AOAS312",
-volume = "3",
-year = "2009"
-}
-
-@ARTICLE{192468,
-author={S. Peleg and M. Werman and H. Rom},
-journal={IEEE Transactions on Pattern Analysis and Machine Intelligence},
-title={A unified approach to the change of resolution: space and gray-level},
-year={1989},
-volume={11},
-number={7},
-pages={739-742},
-keywords={computer vision;graph theory;computer vision;graph theory;gray-level requantization;gray-tone image;half-tone image;resolution change;spatial resampling;Application software;Computer graphics;Computer vision;Image analysis;Image coding;Image resolution;Read only memory;Signal resolution;Spatial resolution;Tail},
-doi={10.1109/34.192468},
-ISSN={0162-8828},
-month={Jul},}
-
-@article{ALBRECHT1990278,
-title = "Search for hadronic b->u decays",
-journal = "Physics Letters B",
-volume = "241",
-number = "2",
-pages = "278 - 282",
-year = "1990",
-issn = "0370-2693",
-doi = "https://doi.org/10.1016/0370-2693(90)91293-K",
-url = "http://www.sciencedirect.com/science/article/pii/037026939091293K",
-author = "H. Albrecht and R. GlÃ€ser and G. Harder and A. KrÃŒger and A.W. Nilsson and A. Nippe and T. Oest and M. Reidenbach and M. SchÃ€fer and W. Schmidt-Parzefall and H. SchrÃ¶der and H.D. Schulz and F. Sefkow and R. Wurth and R.D. Appuhn and A. Drescher and C. Hast and G. Herrera and H. Kolanoski and A. Lange and A. Lindner and R. Mankel and H. Scheck and G. Schweda and B. Spaan and A. Walther and D. Wegener and M. Paulini and K. Reim and U. Volland and H. Wegener and W. Funk and J. Stiewe and S. Werner and S. Ball and J.C. Gabriel and C. Geyer and A. HÃ¶lscher and W. Hofmann and B. Holzer and S. Khan and J. Spengler and C.E.K. Charlesworth and K.W. Edwards and W.R. Frisken and H. Kapitza and P. Krieger and R. Kutschke and D.B. Macfarlene and K.W. McLean and R.S. Orr and J.A. Parsons and P.M. Patel and J.D. Prentice and S.C. Seidel and J.D. Swain and G. Tsipolitis and K. Tzamariudaki and T.-S. Yoon and T. Ruf and S. Schael and K.R. Schubert and K. Strahl and R. Waldi and S. Weseler and B. BoÅ¡tjanÄiÄ and G. Kernel and P. KriÅŸan and E. KriÅŸniÄ and H.I. CronstrÃ¶m and L. JÃ¶nsson and A. Babaev and M. Danilo and B. Fominykh and A. Golutvin and I. Gorelov and V. Lubimov and A. Rostovtsev and A. Semenov and S. Semenov and V. Shevchenko and V. Soloshenko and V. Tchistilin and I. Tichomirov and Yu. Zaitsev and R. Childers and C.W. Darden"
-}
-
 @article{Griffiths5228,
 	author = {Griffiths, Thomas L. and Steyvers, Mark},
 	title = {Finding scientific topics},


### PR DESCRIPTION
Though I'm (really) not the person to draft the stats 'recent technical improvements' section, sometimes it is helpful to have a starting skeleton for the experts to chip away at / improve (or direct me to make changes).

My strategy for compiling this section, since I only occasionally review stats PRs, was to parse the changelogs for scipy.stats over the last few releases and just look for i.e., major additions or design changes.

For a start I tried to parse the logs back through 0.17, but not 0.16 (yet--depending on how much we want in here).