### PR TITLE
Drafted ckdtree sparse distance matrix section

### DIFF
--- a/scipy-1.0/ckdtree.tex
+++ b/scipy-1.0/ckdtree.tex
@@ -23,7 +23,28 @@ as \texttt{np.arange(max(k))}.
 
 \subsubsection{sparse distance matrix}
 
-generating approximated sparse distance matrix
+In 2015 SciPy added support for generating approximated sparse distance matrices 
+between \texttt{KDTree} objects (sets of points organized into a binary space 
+partitioning data structure\cite{Bentley:1975:MBS:361002.361007}). 
+The user provides a maximum distance value
+above which all distances between points in two provided \texttt{KDTree} objects
+are set to 0. The distance metric used between k-d trees is not constrained
+to the conventional L2 (Euclidean) norm---any Minkowski p-norm value
+bounded by 1 and infinity is valid. By default, a dictionary of keys
+based sparse matrix is the returned data structure. Previously-published
+results had suggested that a hashing approach to sparse matrix assembly
+is 7 times faster than constructing with compressed row format (CSR)\cite{10.1007/978-3-540-75755-9_107}.
+The dictionary object maps row and column indices to elements of the sparse matrix, which is
+efficient for matrix construction because all zero values are skipped in
+the dictionary mapping. The C++ level sparse matrix construction releases the Python
+global interpreter lock for increased performance. Once constructed, the
+dictionary of keys sparse matrix has the amortized constant time complexity 
+($O(1)$) for distance value retrieval that one would expect from a 
+dictionary\cite{Cormen:2001:IA:580470}. For efficiently performing arithmetic
+operations on the sparse matrix, SciPy allows the dictionary of keys
+sparse matrix to be directly converted to the common CSR, CSC, and COO
+data structures.
+
 
 \subsubsection{Pair-Counting}
 

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -781,3 +781,49 @@ urldate = {2018-07-06}
  address = {Secaucus, NJ, USA},
  keywords = {Nearest-neighbor search, Searching, k-dimensional tree},
 }
+
+@book{Cormen:2001:IA:580470,
+ author = {Cormen, Thomas H. and Stein, Clifford and Rivest, Ronald L. and Leiserson, Charles E.},
+ title = {Introduction to Algorithms},
+ year = {2001},
+ isbn = {0070131511},
+ edition = {2nd},
+ publisher = {McGraw-Hill Higher Education},
+}
+
+@article{Bentley:1975:MBS:361002.361007,
+ author = {Bentley, Jon Louis},
+ title = {Multidimensional Binary Search Trees Used for Associative Searching},
+ journal = {Commun. ACM},
+ issue_date = {Sept. 1975},
+ volume = {18},
+ number = {9},
+ month = sep,
+ year = {1975},
+ issn = {0001-0782},
+ pages = {509--517},
+ numpages = {9},
+ url = {http://doi.acm.org/10.1145/361002.361007},
+ doi = {10.1145/361002.361007},
+ acmid = {361007},
+ publisher = {ACM},
+ address = {New York, NY, USA},
+ keywords = {associative retrieval, attribute, binary search trees, binary tree insertion, information retrieval system, intersection queries, key, nearest neighbor queries, partial match queries},
+}
+
+@InProceedings{10.1007/978-3-540-75755-9_107,
+author="Aspn{\"a}s, Mats
+and Signell, Artur
+and Westerholm, Jan",
+editor="K{\aa}gstr{\"o}m, Bo
+and Elmroth, Erik
+and Dongarra, Jack
+and Wa{\'{s}}niewski, Jerzy",
+title="Efficient Assembly of Sparse Matrices Using Hashing",
+booktitle="Applied Parallel Computing. State of the Art in Scientific Computing",
+year="2007",
+publisher="Springer Berlin Heidelberg",
+address="Berlin, Heidelberg",
+pages="900--907",
+isbn="978-3-540-75755-9"
+}


### PR DESCRIPTION
I found a few (hopefully) pertinent references by digging through the literature. I don't actually see any citations directly associated with the dictionary of keys sparse matrix approach, but I did find previously-published work that confirms the merit of using a hash-table data structure for constructing a sparse matrix. Amazingly, wikipedia cites the SciPy implementation of dictionary of keys sparse matrix and nothing else for "dok sparse matrices."

Anyway, hopefully this is a sensible start for this tech improvements section.