### PR TITLE
Add citation for chain mesh vs. k-d tree performance

### DIFF
--- a/scipy-1.0/ckdtree.tex
+++ b/scipy-1.0/ckdtree.tex
@@ -54,5 +54,5 @@ correlation functions of galaxies\cite{0004-637X-750-1-38}.
 The main purpose of the paircounting algorithm in cKDTree is to provide a readily
 available tool. The KDTree based algorithm is not necessarily the fastest algorithm
 depending on the application. E.g. for low number densities a chaining mesh based algorithm
-can be easily many times faster than a tree based algorithm.
+can be easily many times faster than a tree based algorithm\cite{1991ApJ}.
 

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -921,3 +921,17 @@ year = 2018,
 url = {https://software.intel.com/en-us/articles/intel-optimized-packages-for-the-intel-distribution-for-python},
 urldate = {2018-07-25}
 }
+
+@ARTICLE{1991ApJ,
+   author = {{Couchman}, H.M.P.},
+    title = "{Mesh-refined P3M - A fast adaptive N-body algorithm}",
+  journal = {Astrophysical Journal},
+ keywords = {Computational Astrophysics, Computational Grids, Galactic Clusters, Many Body Problem, Particle Density (Concentration), Algorithms, Fourier Transformation},
+     year = 1991,
+    month = feb,
+   volume = 368,
+    pages = {L23-L26},
+      doi = {10.1086/185939},
+   adsurl = {http://adsabs.harvard.edu/abs/1991ApJ...368L..23C},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}


### PR DESCRIPTION
The cited manuscript mentions a mesh algorithm outperforming a tree-based code in its abstract, which seems relevant to the discussion here.