### PR TITLE
Cite astropy in broader community section draft

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -592,7 +592,15 @@ functions, parabolic cylinder functions, and spheroidal wave functions.
 
 \subsection*{Community beyond the SciPy library}
 
-\fixme{TODO}
+The scientific Python ecosystem includes many examples
+of domain-specific software libraries building on top
+of SciPy features, and then returning to the base SciPy library
+to suggest and even implement improvements to enable
+more effective science applications. For example, there
+are common contributors to the SciPy and astropy core
+libraries\cite{astropy-2018}, and what works well for 
+one of the code bases, infrastructures, or communities 
+is often transferred in some form to the other.
 
 \subsection*{Maintainers and contributors}
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -601,8 +601,9 @@ are common contributors to the SciPy and astropy core
 libraries\cite{astropy-2018}, and what works well for 
 one of the code bases, infrastructures, or communities 
 is often transferred in some form to the other. At the code
-base level, the \texttt{binned\_statistics} functionality
-was initially developed in an Astropy-affiliated package
+base level, the \texttt{binned\_statistic} functionality
+is one such cross-project contribution---it was initially
+developed in an Astropy-affiliated package
 and then placed in SciPy after the fact.
 
 \subsection*{Maintainers and contributors}

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -600,7 +600,10 @@ more effective science applications. For example, there
 are common contributors to the SciPy and astropy core
 libraries\cite{astropy-2018}, and what works well for 
 one of the code bases, infrastructures, or communities 
-is often transferred in some form to the other.
+is often transferred in some form to the other. At the code
+base level, the \texttt{binned\_statistics} functionality
+was initially developed in an Astropy-affiliated package
+and then placed in SciPy after the fact.
 
 \subsection*{Maintainers and contributors}
 

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -968,3 +968,32 @@ urldate = {2018-07-25}
   year      = { 2015 },
   editor    = { {K}athryn {H}uff and {J}ames {B}ergstra }
 }
+
+@article{astropy-2018,
+  author={The Astropy Collaboration and A. M. Price-Whelan and B. M. Sipőcz and H. M. Günther and P. L. Lim and S. M. Crawford and S.
+Conseil and D. L. Shupe and M. W. Craig and N. Dencheva and A. Ginsburg and J. T. VanderPlas and L. D. Bradley and D.
+Pérez-Suárez and M. de Val-Borro and (Primary Paper Contributors) and T. L. Aldcroft and K. L. Cruz and T. P.
+Robitaille and E. J. Tollerud and (Astropy Coordination Committee) and C. Ardelean and T. Babej and Y. P. Bach and M.
+Bachetti and A. V. Bakanov and S. P. Bamford and G. Barentsen and P. Barmby and A. Baumbach and K. L. Berry and F. Biscani and M.
+Boquien and K. A. Bostroem and L. G. Bouma and G. B. Brammer and E. M. Bray and H. Breytenbach and H. Buddelmeijer and D. J.
+Burke and G. Calderone and J. L. Cano Rodríguez and M. Cara and J. V. M. Cardoso and S. Cheedella and Y. Copin and L.
+Corrales and D. Crichton and D. D’Avella and C. Deil and É. Depagne and J. P. Dietrich and A. Donath and M. Droettboom and N.
+Earl and T. Erben and S. Fabbro and L. A. Ferreira and T. Finethy and R. T. Fox and L. H. Garrison and S. L. J. Gibbons and D. A.
+Goldstein and R. Gommers and J. P. Greco and P. Greenfield and A. M. Groener and F. Grollier and A. Hagen and P. Hirst and D.
+Homeier and A. J. Horton and G. Hosseinzadeh and L. Hu and J. S. Hunkeler and Ž. Ivezić and A. Jain and T. Jenness and G. Kanarek and S.
+Kendrew and N. S. Kern and W. E. Kerzendorf and A. Khvalko and J. King and D. Kirkby and A. M. Kulkarni and A. Kumar and A. Lee and D.
+Lenz and S. P. Littlefair and Z. Ma and D. M. Macleod and M. Mastropietro and C. McCully and S. Montagnac and B. M. Morris and M.
+Mueller and S. J. Mumford and D. Muna and N. A. Murphy and S. Nelson and G. H. Nguyen and J. P. Ninan and M. Nöthe and S. Ogaz and S.
+Oh and J. K. Parejko and N. Parley and S. Pascual and R. Patil and A. A. Patil and A. L. Plunkett and J. X. Prochaska and T.
+Rastogi and V. Reddy Janga and J. Sabater and P. Sakurikar and M. Seifert and L. E. Sherbert and H. Sherwood-Taylor and A. Y.
+Shih and J. Sick and M. T. Silbiger and S. Singanamalla and L. P. Singer and P. H. Sladen and K. A. Sooley and S. Sornarajah and O.
+Streicher and P. Teuben and S. W. Thomas and G. R. Tremblay and J. E. H. Turner and V. Terrón and M. H. van Kerkwijk and A. de
+la Vega and L. L. Watkins and B. A. Weaver and J. B. Whitmore and J. Woillez and V. Zabalza and (Astropy Contributors)},
+  title={The Astropy Project: Building an Open-science Project and Status of the v2.0 Core Package},
+  journal={The Astronomical Journal},
+  volume={156},
+  number={3},
+  pages={123},
+  url={http://stacks.iop.org/1538-3881/156/i=3/a=123},
+  year={2018},
+}


### PR DESCRIPTION
I read through the recent community-focused [astropy manuscript](http://iopscience.iop.org/article/10.3847/1538-3881/aabc4f) and thought it might be suitable to at least cite them in a community-related section of our paper.

There are common authors on both projects (and I'm not one, so that removes some bias), and I think there has been some decent exchange of ideas / things that worked well between the two connected communities.

They cite NumPy and SciPy as building blocks in their manuscript, and several conference proceedings where @stefanv and @jarrodmillman were editors, etc., so community connection.

A *specific* example of transfer back to SciPy, if there is one that comes to mind, might make this more compelling if others think it is a good idea--this may not be the right subsection for the content though.