### PR TITLE
Add linguist citation

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -724,8 +724,9 @@ Python 2 / 3?
 
 Python, Cython, Fortran, C and C++ are the programming languages used to
 implement scientific algorithms in the SciPy library. An analysis of our code
-base using the \texttt{linguist} library provides a detailed breakdown as \%
-composition by programming language in SciPy (Figure~\ref{fig:linguist}).
+base using the \texttt{linguist} library\cite{linguistref} provides a 
+detailed breakdown as \% composition by programming language in 
+SciPy (Figure~\ref{fig:linguist}).
 
 \begin{figure}[H]
     \centering

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -1241,3 +1241,11 @@ la Vega and L. L. Watkins and B. A. Weaver and J. B. Whitmore and J. Woillez and
   url={http://stacks.iop.org/1538-3881/156/i=3/a=123},
   year={2018},
 }
+
+@online{linguistref,
+author = {{Linguist developers; open source community}},
+title = {linguist},
+year = 2019,
+url = {https://github.com/github/linguist},
+urldate = {2019-1-12}
+}


### PR DESCRIPTION
Add a citation for the [linguist library](https://github.com/github/linguist), which is a task described in #65.

I didn't see any Zenodo DOIs on their releases, etc., so simply citing their GitHub page.