### PR TITLE
Correct company & preferred citation for VTK

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -391,7 +391,7 @@ the next generation of graduate students and postdocs were already exploring
 other aspects of the computational environment.
 In 2000, Prabhu Ramachandran, a PhD student at the Indian Institute of
 Technology, started work on a 3D visualization application, based on
-Wingware's C++ Visualization Toolkit, called
+Kitware's C++ Visualization Toolkit\cite{schroeder:2006:VTK}, called
 Mayavi\footnote{https://web.archive.org/web/20030731122452/http://pythonology.org/success\&story=mayavi}.
 In 2001, Fernando Pérez, a graduate student at the University of
 Colorado, Boulder, created the IPython interactive shell (that would

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -1266,3 +1266,12 @@ year = 2019,
 url = {https://github.com/airspeed-velocity/asv},
 urldate = {2019-1-14}
 }
+
+@Book{schroeder:2006:VTK,
+author = "Will Schroeder and Ken Martin and Bill Lorensen",
+title = {{The Visualization Toolkit}},
+publisher = "Kitware",
+year = "2006",
+edition = 4,
+isbn = {978-1-930934-19-1},
+}


### PR DESCRIPTION
Checklist item from #65.

- VTK is actually associated with `Kitware`, and ownership actually appears to remain with the original authors who wrote code in spare time while working at GE before forming `Kitware`.
- cite the preferred (textbook) source according to [VTK about page](https://vtk.org/about/)