### PR TITLE
Fill in first year US SciPy had > 1 track

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -597,7 +597,7 @@ published proceedings, and scholarships for attending students (some
 of whom are authors on this paper).  In 2010, the conference grew even
 further, with an additional event added in India, and the US
 conference—now with parallel tracks—moving to Austin, Texas.
-While the US SciPy conference kept growing (by ... it had multiple
+While the US SciPy conference kept growing (by 2010 it had multiple
 tracks, student sponsorship, proceedings, and funding), satellite
 events were being organized by volunteers elsewhere, such as EuroSciPy
 (2008–) and SciPy India (2009–).


### PR DESCRIPTION
Checklist item from #65.

Just fill in the first year that SciPy US conference had multiple tracks, which was previously just a set of ellipses. That said, this information is a little redundant with previous sentence.

Looks like student sponsorship & proceedings preceded the multi-track format based on schedules available at https://conference.scipy.org/past.html

