### PR TITLE
Project Scope cleanup / improvement

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -643,18 +643,20 @@ Software classification system (GAMS\cite{boisvert1991guide}). In areas
 that move relatively slowly, e.g. linear algebra, SciPy aims to provide
 complete coverage. In other areas it aims to provide fundamental building
 blocks while interacting well with other packages specialized in that area.
-For example, SciPy provides what one expect to find in a
+For example, SciPy provides what one expects to find in a
 statistics textbook (probability distributions, hypothesis tests, frequency
-statistics, correlation functions, and more), while Statsmodels provides
-more advanced statistical estimators and inference methods, scikit-learn
-covers machine learning, PyMC3, emcee and PyStan cover Bayesian statistics
-and probabilistic modeling.
-
-scikit-image
-
-sympy\cite{meurer2017sympy}
-
-NetworkX\cite{hagberg2008networkx}
+statistics, correlation functions, and more), while 
+Statsmodels\cite{statsmodels2010} provides
+more advanced statistical estimators and inference methods;
+scikit-learn\cite{pedregosa2011scikit} covers machine learning; and
+PyMC3\cite{10.7717/peerj-cs.55}, emcee\cite{2013PASP-emcee} and 
+PyStan\cite{pystan-ref} cover Bayesian statistics and probabilistic modeling.
+scikit-image\cite{vanderwalt2014scikit} provides image processing
+capabilities beyond \texttt{scipy.ndimage}, sympy\cite{meurer2017sympy}
+provides a Python interface for symbolic computation, and
+NetworkX\cite{hagberg2008networkx} is a Python library for probing
+graphs and networks in a more specialized way than SciPy components
+like \texttt{sparse.csgraph} or \texttt{spatial}.
 
 We use the following criteria to determine whether or not to include new
 functionality in SciPy:

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -1275,3 +1275,54 @@ year = "2006",
 edition = 4,
 isbn = {978-1-930934-19-1},
 }
+
+% appears to be the preferred statsmodels reference;
+% has been cited > 300 times
+@inproceedings{statsmodels2010,
+title={Statsmodels: Econometric and Statistical Modeling with Python},
+author={Seabold, J.S. and Perktold, J.},
+booktitle={Proceedings of the 9th Python in Science Conference},
+year={2010}
+}
+
+% preferred PyMC3 citation from https://docs.pymc.io/
+@article{10.7717/peerj-cs.55,
+ title = {Probabilistic programming in Python using PyMC3},
+ author = {Salvatier, John and Wiecki, Thomas V. and Fonnesbeck, Christopher},
+ year = 2016,
+ month = apr,
+ keywords = {Bayesian statistic, Probabilistic Programming, Python, Markov chain Monte Carlo, Statistical modeling},
+ volume = 2,
+ pages = {e55},
+ journal = {PeerJ Computer Science},
+ issn = {2376-5992},
+ url = {https://doi.org/10.7717/peerj-cs.55},
+ doi = {10.7717/peerj-cs.55}
+}
+
+% preferred emcee citation: http://dfm.io/emcee/current/#license-attribution
+@ARTICLE{2013PASP-emcee,
+   author = {{Foreman-Mackey}, D. and {Hogg}, D.~W. and {Lang}, D. and {Goodman}, J.
+	},
+    title = "{emcee: The MCMC Hammer}",
+  journal = {Publications of the Astronomical Society of the Pacific},
+archivePrefix = "arXiv",
+   eprint = {1202.3665},
+ primaryClass = "astro-ph.IM",
+     year = 2013,
+    month = mar,
+   volume = 125,
+    pages = {306},
+      doi = {10.1086/670067},
+   adsurl = {http://adsabs.harvard.edu/abs/2013PASP..125..306F},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+% How to Cite Stan: https://mc-stan.org/users/citations/
+@online{pystan-ref,
+author = {{Stan Development Team}},
+title = {{PyStan: the Python interface to Stan}},
+year = 2018,
+url = {http://mc-stan.org},
+urldate = {2019-1-15}
+}


### PR DESCRIPTION
Aims to resolve the following checklist items from #65 related to Project Scope subsection:

- "...SciPy provides what one expect to find..."
  - cite the other projects mentioned in this sentence, at least if they haven't already been cited before in the paper
  - "expects"
  - the sentence is then abruptly followed with an unlabeled list, and this needs to be cleaned up