### PR TITLE
Clean up Current Status subsection

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -670,18 +670,16 @@ algorithms for in-memory computing on single machines, with support for a wide
 range of data types and process architectures. Distributed computing and support
 for graphics processing units (GPUs) is explicitly out of scope.
 
-\subsection*{Current status (maturity, users)}
+\subsection*{Current status}
 
-SciPy 1.0 was released ... see timeline ...
+At the time of writing, SciPy produces a new release
+approximately every six months, and some of the major
+feature highlights from the three years preceding
+SciPy 1.0 are discussed in a technical improvements
+section below. Some longer-term milestone events are
+highlighted in Figure~\ref{fig:timeline}.
 
-1.1 ...
-
-1.2
-
-Python 2 / 3?
-
-
-\begin{figure}
+\begin{figure}[H]
 \begin{verbatim}
     2001: first SciPy release
     2005: transition to NumPy
@@ -698,6 +696,7 @@ Python 2 / 3?
     2017: SciPy 1.0 release
 \end{verbatim}
 \caption{Timeline}
+\label{fig:timeline}
 \end{figure}
 
 % Release management


### PR DESCRIPTION
For checklist item in #65:

- Current status (maturity, users) subsection
  - this subsection looks messy / undeveloped with question marks and ellipses & then just mentioning the timeline figure which isn't even cited in LaTeX

Also, I think Ralf mentioned he was "ok" with the paper stopping at 1.0 (that's kind of the point, I guess), rather than getting into `1.1`, `1.2`, and the latest stuff.