### PR TITLE
Clean up PyData sentence

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -633,7 +633,8 @@ came from the scientific Python stack.
 Today it has over 25 sponsored projects including NumPy, SciPy, IPython, and
 Matplotlib.
 Among its other projects, NumFOCUS organizes a global network of 
-community driven educational program called PyData.
+community driven educational programs, meetups, and conferences
+called PyData.
 
 \subsection*{Project scope}
 


### PR DESCRIPTION
Checklist items from #65:

-  "...NumFOCUS organizes a global network of community driven educational program called PyData"
   - maybe conferences / meetups instead of or in addition to program?
   - certainly program should be plural at least?