### PR TITLE
Clarify that Cython bindings are recent

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -901,10 +901,11 @@ generate a low-level callback function automatically from a Cython module using
 
 \subsection*{Cython bindings for BLAS, LAPACK, and special}
 
-SciPy now includes Cython\cite{behnel2011cython} wrappers for many BLAS and
-LAPACK\cite{LAPACK} routines (added in 2015) and for the special functions
-provided in the
-\texttt{scipy.{\allowbreak}special} submodule (added in 2016).  
+SciPy has provided special functions and leveraged BLAS and
+LAPACK\cite{LAPACK} routines for many years. SciPy now additionally
+includes Cython\cite{behnel2011cython} wrappers for:
+many BLAS and LAPACK routines (added in 2015), and the special functions 
+provided in the \texttt{scipy.{\allowbreak}special} submodule (added in 2016).  
 These Cython wrappers are available in the modules
 \texttt{scipy.{\allowbreak}linalg.{\allowbreak}cython\_blas},
 \texttt{scipy.{\allowbreak}linalg.{\allowbreak}cython\_lapack}, and


### PR DESCRIPTION
For checklist item from #65:

> Cython bindings for BLAS, LAPACK, and special
> this is a subsection of "technical improvements" -- if this was one of the things added in last 3 years we should clarify that somewhere in the discussion -- i.e., switch language from "Scipy includes... " to "Scipy now includes..."

I added the master branch merge dates for the two major associated PRs I could find:
- https://github.com/scipy/scipy/pull/4021 merged March 2015 [BLAS, LAPACK]
- https://github.com/scipy/scipy/pull/6195 merged July 2016 [special]

One drawback of my parenthetical notes is that they may cause confusion re: date association with implementation of submodule vs. the Cython interface for someone unfamiliar with SciPy, I suppose.

I didn't cite the PRs directly because of our ballooning reference count.