### PR TITLE
Cite SciPy impact on machine learning from GitHub report

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -104,7 +104,8 @@ version 0.1 release. SciPy
 has become a \emph{de facto} standard for leveraging scientific algorithms
 in the Python programming language, with more than 600
 unique code contributors, millions of downloads per year, 161 dependent
-packages, and 28700 dependent repositories.
+packages, and 28700 dependent repositories. This includes usage of SciPy
+in almost half of all machine learning projects on GitHub.
 The library includes functionality spanning clustering, Fourier transforms,
 integration, interpolation, file I/O, linear algebra, image processing,
 orthogonal distance regression, minimization algorithms, signal processing,
@@ -1154,7 +1155,8 @@ peer-reviewed paper, has been cited $>3000$ times. Some of the most prominent
 usages of or demonstrations of credibility for SciPy include the LIGO / Virgo
 scientific collaboration that lead to the observation of gravitational waves
 \cite{PhysRevLett.116.061102}, and the fact that SciPy is shipped directly with
-MacOS and in the Intel Distribution for Python\cite{intel-python}. 
+MacOS and in the Intel Distribution for Python\cite{intel-python}. SciPy is used
+by 47 \% of all machine learning projects on GitHub\cite{octoverse-scipy}.
 
 \subsection*{Future Work}
 

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -1571,3 +1571,11 @@ year = 2006,
 url = {https://github.com/numpy/numpy/releases/tag/v1.0},
 urldate = {2019-1-25}
 }
+
+@online{octoverse-scipy,
+author = {{Thomas Elliott}},
+title = {{The State of the Octoverse: Machine Learning}},
+year = 2019,
+url = {https://github.blog/2019-01-24-the-state-of-the-octoverse-machine-learning/},
+urldate = {2019-1-25}
+}


### PR DESCRIPTION
Fixes #88.

Cite the GitHub article for SciPy impact on machine learning community in abstract + appropriate section of manuscript.