### PR TITLE
Improvements to cKDTree paragraph 4

### DIFF
--- a/scipy-1.0/ckdtree.tex
+++ b/scipy-1.0/ckdtree.tex
@@ -34,8 +34,7 @@ operations on the sparse matrix, SciPy allows the dictionary of keys
 sparse matrix to be directly converted to the common CSR, CSC, and COO
 data structures.
 
-The cKDTree module implements a dual tree counting algorithm\cite{Moore2000ar},
-with an improvement to the pair counting algorithm to improve the scaling
-with the number of bins. The cKDTree can now be augmented by weights, with 
-weighted paircount essential in many scientific applications, e.g. computing 
-correlation functions of galaxies\cite{0004-637X-750-1-38}.
+In 2015 the cKDTree dual tree counting algorithm\cite{Moore2000ar}
+was enhanced to support weights\cite{ckdtree-weights}, which are
+essential in many scientific applications, e.g. computing correlation
+functions of galaxies\cite{0004-637X-750-1-38}.

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -1671,3 +1671,11 @@ urldate = {2019-1-28}
     year = {1999},
     url= {https://arxiv.org/pdf/cs/9901013.pdf}
 }
+
+@online{ckdtree-weights,
+author = {{Yu Feng}},
+title = {{ENH: Faster count\_neighour in cKDTree weighted input data}},
+year = 2015,
+url = {https://github.com/scipy/scipy/pull/5647},
+urldate = {2019-1-28}
+}


### PR DESCRIPTION
Checklist item from #65:

> sentence starting "The cKDTree module implements a dual tree counting algorithm..." is a bit sudden / list-like

Specific improvements include dates / PR links for feature additions to clarify what is actually new, and usage of the actual function / method name for clarity. We could also add `d0afcaf6a` for the initial addition of `count_neighbors`, though I've just added the year for that since it is not a recent improvement. The `cKDTree` docstring is consistent with the primary literature citation originally used, so that should be okay. The use of that algorithm is described as "loose," but good enough I think.