### PR TITLE
Remove extraneous content near end of KDTree section

### DIFF
--- a/scipy-1.0/ckdtree.tex
+++ b/scipy-1.0/ckdtree.tex
@@ -45,13 +45,3 @@ with an improvement to the pair counting algorithm to improve the scaling
 with the number of bins. The cKDTree can now be augmented by weights, with 
 weighted paircount essential in many scientific applications, e.g. computing 
 correlation functions of galaxies\cite{0004-637X-750-1-38}.
-
-\fixme{Add a Figure to show the scaling, before and after.}
-\fixme{perhaps give an example or some formula.}
-(cite / mention faster implementions of paircounting algorithms / treecorr, corrfunc)
-
-The main purpose of the paircounting algorithm in cKDTree is to provide a readily
-available tool. The KDTree based algorithm is not necessarily the fastest algorithm
-depending on the application. E.g. for low number densities a chaining mesh based algorithm
-can be easily many times faster than a tree based algorithm.
-


### PR DESCRIPTION
Meant to address checklist item from #65:

> There's a TODO-style sentence in this section with "Add a Figure to show the scaling, before and after. perhaps give an example or some formula. (cite / mention faster implementions of paircounting algorithms / treecorr, corrfunc)"

This PR proposes to remove that TODO-style content, and we're already providing the correct citation for the main algorithm if the reader wants to explore the literature in greater detail. The docstring for `cKDTree` also contains citations for example applications and example formula, etc. Plus Figure 4 is actually already a cKDtree performance improvement plot.

Alternatively, the content could be moved to the supporting information and filled in there, but unless someone wants to do that very soon, I suggest just removing given length / interest constraints.