### PR TITLE
Remove common infra change subsection

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -731,8 +731,6 @@ highlighted in Figure~\ref{fig:timeline}.
 
 \input{subpackages}
 
-\subsection*{Common infrastructure}
-
 \subsection*{Language choices}
 
 Python, Cython, Fortran, C and C++ are the programming languages used to


### PR DESCRIPTION
For checklist item from #65:

> Common Infrastructure
  This subsection is blank -- do we want to keep it?

This PR proposes removing it. Alternatively, we could shift to supporting information, but only if someone is proposing specific content or willing to write it.