### PR TITLE
Cite SciPy Developer Guide

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1127,8 +1127,8 @@ of the project\cite{eghbal2016}; their skills and efforts largely determine how
 fast the project moves forward, and they enable contributions from a much
 larger group. Accordingly, the project also has an additional ~100 unique
 contributors for every 6-monthly release cycle. Anyone with the interest and
-skills can become a contributor or maintainer; the SciPy Developer Guide
-provides guidance on how to do that.
+skills can become a contributor or maintainer; the SciPy Developer
+Guide\cite{scipy-dev-guide} provides guidance on how to do that.
 
 \section*{Discussion}
 

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -1587,3 +1587,11 @@ year = 2019,
 url = {https://github.blog/2019-01-24-the-state-of-the-octoverse-machine-learning/},
 urldate = {2019-1-25}
 }
+
+@online{scipy-dev-guide,
+author = {{SciPy Developers}},
+title = {{SciPy Developer Guide}},
+year = 2019,
+url = {https://scipy.github.io/devdocs/dev/index.html},
+urldate = {2019-1-31}
+}


### PR DESCRIPTION
For checklist item in #65:

> Maintainers and contributors
  citation / link for SciPy Developer Guide maybe

It is hardly desirable to add more citations, and if that is the decision we can close this and check off the item. Otherwise, this directs the reader to our dev guide for contributing.