### PR TITLE
Shift optimize background content for concision of main text

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1263,6 +1263,18 @@ Some additional roadmap items are summarized in Table~\ref{table:roadmap}.
 \label{fig:sparse-conv}
 \end{figure}
 
+\section*{Numerical Optimization: Additional Details}
+The \texttt{scipy.optimize} module provides functions for the numerical solution of several classes of root finding and optimization problems:
+\begin{enumerate}
+\item nonlinear root finding problems (\texttt{brentq}, \texttt{brenth}, \texttt{ridder}, \texttt{bisect}, \texttt{newton}, and \texttt{root}),
+\item linear sum assignment problems (\texttt{linear\textunderscore sum\textunderscore assignment}),
+\item linear and nonlinear sum-of-squares problems (\texttt{leastsq}, \texttt{least\textunderscore squares}, \texttt{nnls}, \texttt{lsq\textunderscore linear}, and \texttt{curve\textunderscore fit}),
+\item general, linear optimization problems (\texttt{linprog}),
+\item general, nonlinear, local optimization problems of a single variable (\texttt{minimize\textunderscore scalar}),
+\item general, nonlinear, local optimization problems of several variables (\texttt{minimize}), and
+\item general, nonlinear, global optimization problems of several variables (\texttt{basinhopping}, \texttt{brute}, \texttt{differential\textunderscore evolution}).
+\end{enumerate}
+
 %To include, in this order: \textbf{Accession codes} (where applicable);
 %\textbf{Competing financial interests} (mandatory statement).
 

--- a/scipy-1.0/scipy-optimize.tex
+++ b/scipy-1.0/scipy-optimize.tex
@@ -1,15 +1,7 @@
 \newcommand{\RR}{\ensuremath{\mathbb{R}}}
-The \texttt{scipy.optimize} module provides functions for the numerical solution of several classes of root finding and optimization problems:
-\begin{enumerate}
-\item nonlinear root finding problems (\texttt{brentq}, \texttt{brenth}, \texttt{ridder}, \texttt{bisect}, \texttt{newton}, and \texttt{root}),
-\item linear sum assignment problems (\texttt{linear\textunderscore sum\textunderscore assignment}),
-\item linear and nonlinear sum-of-squares problems (\texttt{leastsq}, \texttt{least\textunderscore squares}, \texttt{nnls}, \texttt{lsq\textunderscore linear}, and \texttt{curve\textunderscore fit}),
-\item general, linear optimization problems (\texttt{linprog}),
-\item general, nonlinear, local optimization problems of a single variable (\texttt{minimize\textunderscore scalar}),
-\item general, nonlinear, local optimization problems of several variables (\texttt{minimize}), and
-\item general, nonlinear, global optimization problems of several variables (\texttt{basinhopping}, \texttt{brute}, \texttt{differential\textunderscore evolution}).
-\end{enumerate}
-Documentation of SciPy's functionality in each these areas can be found in (cite SciPy documentation), but here we highlight recent additions through SciPy 1.0.
+The \texttt{scipy.optimize} module provides functions for the numerical
+solution of several classes of root finding and optimization problems.
+Here we highlight recent additions through SciPy 1.0.
 
 %\subsubsection{Root Finding}
 %The general ``root finding'' problem is to find a root $\mathbf{x} \in \RR^m$ of $\mathbf{f}: \RR^m \rightarrow \RR^m$, that is, to solve

--- a/scipy-1.0/subpackages.tex
+++ b/scipy-1.0/subpackages.tex
@@ -60,7 +60,7 @@ Here we summarize the scope and capabilities of each subpackage.
     Orthogonal distance regression, including Python wrappers for the Fortran
     library ODRPACK.
 \item[\texttt{optimize}] ~ \newline
-    The package includes:
+    The package includes the following, with additional details in the SI:
     implementations of many minimization algorithms; a general linear
     programming solver; a routine for least-squares curve fitting; and a
     collection of general nonlinear solvers for root-finding.


### PR DESCRIPTION
For checklist item from #65:

> **Numerical optimization**
> * [ ]  I suspect we should remove the background on what scipy.optimize does with the list of 7 problems -- we should find a way to make this relatively clear & abstract that information to earlier in the paper when the 16 SciPy submodules are described

This PR proposes to fix the issue by moving the longer background content to the SI & citing that SI content from the subpackages description earlier in the manuscript.

cc @antonior92 

There are more simplifications to the optimize section suggested in the checklist for the purpose of concision, but I'll start with this one for now.