### PR TITLE
Table 1 (optimization) concision / recent changes adjustments

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1238,9 +1238,11 @@ Some additional roadmap items are summarized in Table~\ref{table:roadmap}.
 
 \section*{Supporting Information}
 
-% separate Figure numbering for SI
+% separate Figure / Table numbering for SI
 \renewcommand{\thefigure}{S\arabic{figure}}
+\renewcommand{\thetable}{S\arabic{table}}
 \setcounter{figure}{0}
+\setcounter{table}{0}
 
 \begin{figure}[H]
 \centering
@@ -1263,6 +1265,58 @@ Some additional roadmap items are summarized in Table~\ref{table:roadmap}.
 \label{fig:sparse-conv}
 \end{figure}
 
+\begin{table}[H]
+  \centering
+  \caption{Optimization methods from \texttt{minimize} added prior to SciPy 0.13.  The field \textit{version added} specifies the algorithm's first appearance in SciPy. Algorithms with \textit{version added} ``0.6*'' were added in version 0.6 or before.
+    The field \textit{wrapper} indicates whether the implementation available in SciPy wraps a function written in a compiled language
+    (e.g. C or FORTRAN). The fields \textit{\nth{1}} and \textit{\nth{2} derivatives}
+    indicates whether first or second order derivatives are required. When \textit{\nth{2} derivatives} is flagged
+    with $\sim$ the algorithm does not requires second-order derivatives from
+    the user; it computes an approximation internally and uses it to accelerate method convergence.
+    \textit{Iterative Hessian factorization} denotes algorithms that factorize the Hessian in an iterative way,
+    which does not require explicit matrix factorization or storage of the Hessian.
+    \textit{Local convergence} gives a lower bound on the rate of convergence of the iterations sequence once the
+    iterate is sufficiently close to the solution: linear (L), superlinear (S) and quadratic (Q). Convergence rates denoted S$^*$ indicate that the algorithm
+    has a superlinear rate for the parameters used in SciPy, but can  achieve a quadratic convergence rate with other parameter choices.
+    \textit{Global convergence} is marked for the algorithms with guarantees of convergence to a stationary
+    point (i.e. a point $x^*$ for which $\nabla f(x^*) = 0$); this is \emph{not} a guarantee of convergence to a global minimum. The table also indicates which algorithms
+    can deal with constraints on the variables. We distinguish between: \textit{bound constraints} (i.e. $x^l \le x \le x^u$),
+    \textit{equality constraints} (i.e. $c_{\text{eq}}(x) = 0$) and \textit{inequality constraints} (i.e. $c_{\text{ineq}}(x) \ge 0$).}
+  \begin{tabular}{cccccccccccccc}
+      & \rotatebox{80}{\texttt{Nelder-Mead}} & \rotatebox{80}{\texttt{Powell}} & \rotatebox{80}{\texttt{COBYLA}} & \rotatebox{80}{\texttt{CG}} & \rotatebox{80}{\texttt{BFGS}}&  \rotatebox{80}{\texttt{L-BFGS-B}} & \rotatebox{80}{\texttt{SLSQP}} & \rotatebox{80}{\texttt{TNC}} & \rotatebox{80}{\texttt{Newton-CG}}\\
+    \hline
+    Version added &  0.6* &  0.6* &  0.6* &  0.6* &  0.6* &  0.6* &  0.9 &  0.6* &  0.6* \\
+    \hline
+    Wrapper & & & \cmark & & & \cmark & \cmark & \cmark & \\
+    \hline
+    \nth{1} derivatives &  & & & \cmark  & \cmark & \cmark & \cmark & \cmark & \cmark \\
+    \hline
+    \nth{2} derivatives &  &  &  &  & $\sim$ & $\sim$ & $\sim$ & \cmark & \cmark \\
+    \hline
+    \makecell{Iterative Hessian \\
+    factorization} & & & &  & & & & \cmark & \cmark \\
+    \hline
+    Local convergence& & & & L & S &  L & S & S$^*$ & S$^*$ \\
+    \hline
+    Global convergence & & &  &   & \cmark & \cmark & \cmark & \cmark & \cmark \\
+    \hline
+    \makecell{Line-search (LS) or\\ trust-region (TR)} & Neither  & LS &  TR & LS & LS & LS & LS & LS & LS \\
+    \hline
+    Bound constraints &&&\cmark&&&&\cmark&\cmark&\cmark \\
+    \hline
+    Equality constraints &&&&&&&\cmark& \\
+    \hline
+    Inequality constraint &&&\cmark&&&&\cmark& \\
+    \hline
+    References & \cite{nelder_simplex_1965, wright_direct_1996} & \cite{powell_efficient_1964} &
+      \cite{powell_direct_1994, powell_direct_1998, powell_view_2007} &
+      \cite{polak_note_1969, nocedal_numerical_2006} & \cite{nocedal_numerical_2006} & \cite{byrd_limited_1995, zhu_algorithm_1997} &
+      \cite{schittkowski_nonlinear_1982, schittkowski_nonlinear_1982-1, schittkowski_convergence_1983, kraft_software_1988} &
+      \cite{nash_newton-type_1984} & \cite{nocedal_numerical_2006} \\
+    \hline
+  \end{tabular}
+  \label{tab:minimize-si}
+\end{table}
 %To include, in this order: \textbf{Accession codes} (where applicable);
 %\textbf{Competing financial interests} (mandatory statement).
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1267,7 +1267,7 @@ Some additional roadmap items are summarized in Table~\ref{table:roadmap}.
 
 \begin{table}[H]
   \centering
-  \caption{Optimization methods from \texttt{minimize} added prior to SciPy 0.13.  The field \textit{version added} specifies the algorithm's first appearance in SciPy. Algorithms with \textit{version added} ``0.6*'' were added in version 0.6 or before.
+  \caption{Optimization methods from \texttt{minimize}, which solves problems of the form $\min_x f(x)$, where $x \in \mathbb{R}^n$ and $f: \mathbb{R}^n \rightarrow \mathbb{R}$ .  The field \textit{version added} specifies the algorithm's first appearance in SciPy. Algorithms with \textit{version added} ``0.6*'' were added in version 0.6 or before.
     The field \textit{wrapper} indicates whether the implementation available in SciPy wraps a function written in a compiled language
     (e.g. C or FORTRAN). The fields \textit{\nth{1}} and \textit{\nth{2} derivatives}
     indicates whether first or second order derivatives are required. When \textit{\nth{2} derivatives} is flagged
@@ -1283,40 +1283,43 @@ Some additional roadmap items are summarized in Table~\ref{table:roadmap}.
     can deal with constraints on the variables. We distinguish between: \textit{bound constraints} (i.e. $x^l \le x \le x^u$),
     \textit{equality constraints} (i.e. $c_{\text{eq}}(x) = 0$) and \textit{inequality constraints} (i.e. $c_{\text{ineq}}(x) \ge 0$).}
   \begin{tabular}{cccccccccccccc}
-      & \rotatebox{80}{\texttt{Nelder-Mead}} & \rotatebox{80}{\texttt{Powell}} & \rotatebox{80}{\texttt{COBYLA}} & \rotatebox{80}{\texttt{CG}} & \rotatebox{80}{\texttt{BFGS}}&  \rotatebox{80}{\texttt{L-BFGS-B}} & \rotatebox{80}{\texttt{SLSQP}} & \rotatebox{80}{\texttt{TNC}} & \rotatebox{80}{\texttt{Newton-CG}}\\
+      & \rotatebox{80}{\texttt{Nelder-Mead}} & \rotatebox{80}{\texttt{Powell}} & \rotatebox{80}{\texttt{COBYLA}} & \rotatebox{80}{\texttt{CG}} & \rotatebox{80}{\texttt{BFGS}}&  \rotatebox{80}{\texttt{L-BFGS-B}} & \rotatebox{80}{\texttt{SLSQP}} & \rotatebox{80}{\texttt{TNC}} & \rotatebox{80}{\texttt{Newton-CG}} & \rotatebox{80}{\texttt{dogleg}} & \rotatebox{80}{\texttt{trust-ncg}} & \rotatebox{80}{\texttt{trust-exact}} & \rotatebox{80}{\texttt{trust-krylov}} \\
     \hline
-    Version added &  0.6* &  0.6* &  0.6* &  0.6* &  0.6* &  0.6* &  0.9 &  0.6* &  0.6* \\
+    Version added &  0.6* &  0.6* &  0.6* &  0.6* &  0.6* &  0.6* &  0.9 &  0.6* &  0.6* & 0.13 & 0.13 & 0.19 & 1.0 \\
     \hline
-    Wrapper & & & \cmark & & & \cmark & \cmark & \cmark & \\
+    Wrapper & & & \cmark & & & \cmark & \cmark & \cmark & &  & & & \cmark \\
     \hline
-    \nth{1} derivatives &  & & & \cmark  & \cmark & \cmark & \cmark & \cmark & \cmark \\
+    \nth{1} derivatives &  & & & \cmark  & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark \\
     \hline
-    \nth{2} derivatives &  &  &  &  & $\sim$ & $\sim$ & $\sim$ & \cmark & \cmark \\
+    \nth{2} derivatives &  &  &  &  & $\sim$ & $\sim$ & $\sim$ & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark \\
     \hline
     \makecell{Iterative Hessian \\
-    factorization} & & & &  & & & & \cmark & \cmark \\
+    factorization} & & & &  & & & & \cmark & \cmark &  & \cmark &  & \cmark \\
     \hline
-    Local convergence& & & & L & S &  L & S & S$^*$ & S$^*$ \\
+    Local convergence& & & & L & S &  L & S & S$^*$ & S$^*$ & Q & S$^*$ & Q & S$^*$  \\
     \hline
-    Global convergence & & &  &   & \cmark & \cmark & \cmark & \cmark & \cmark \\
+    Global convergence & & &  &   & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark  \\
     \hline
-    \makecell{Line-search (LS) or\\ trust-region (TR)} & Neither  & LS &  TR & LS & LS & LS & LS & LS & LS \\
+    \makecell{Line-search (LS) or\\ trust-region (TR)} & Neither  & LS &  TR & LS & LS & LS & LS & LS & LS & TR & TR & TR & TR \\
     \hline
-    Bound constraints &&&\cmark&&&&\cmark&\cmark&\cmark \\
+    Bound constraints &&&\cmark&&&&\cmark&\cmark&\cmark&&&& \\
     \hline
-    Equality constraints &&&&&&&\cmark& \\
+    Equality constraints &&&&&&&\cmark&&&&& \\
     \hline
-    Inequality constraint &&&\cmark&&&&\cmark& \\
+    Inequality constraint &&&\cmark&&&&\cmark&&&&& \\
     \hline
     References & \cite{nelder_simplex_1965, wright_direct_1996} & \cite{powell_efficient_1964} &
       \cite{powell_direct_1994, powell_direct_1998, powell_view_2007} &
       \cite{polak_note_1969, nocedal_numerical_2006} & \cite{nocedal_numerical_2006} & \cite{byrd_limited_1995, zhu_algorithm_1997} &
       \cite{schittkowski_nonlinear_1982, schittkowski_nonlinear_1982-1, schittkowski_convergence_1983, kraft_software_1988} &
-      \cite{nash_newton-type_1984} & \cite{nocedal_numerical_2006} \\
+      \cite{nash_newton-type_1984} & \cite{nocedal_numerical_2006}  & 
+      \cite{powell_new_1970, nocedal_numerical_2006} &  \cite{steihaug_conjugate_1983, nocedal_numerical_2006} &
+      \cite{conn_trust_2000, more_computing_1983} & \cite{gould_solving_1999, lenders_trlib:_2016} \\
     \hline
   \end{tabular}
   \label{tab:minimize-si}
 \end{table}
+
 %To include, in this order: \textbf{Accession codes} (where applicable);
 %\textbf{Competing financial interests} (mandatory statement).
 

--- a/scipy-1.0/scipy-optimize.tex
+++ b/scipy-1.0/scipy-optimize.tex
@@ -33,7 +33,7 @@ Compared to the previously implemented simplex method, the new interior-point me
 The \texttt{minimize} function provides methods for finding local minima of
 nonlinear optimization problems. It unifies several methods with a common 
 interface in order to facilitate interchanging between solvers with different
-characteristics. Some recent improvements are summarized in Table~\ref{tab:minimize}.
+characteristics. Some recent improvements are summarized in Table~\ref{tab:minimize-si}.
 %% Currently, this introduces a ton of whitespace around a very simple expression (min f(x)). The reader can easily find the standard of meaning of `nonlinear programming', so I believe it should be removed. If we decide that it is appropriate to include, then we should add the entire problem statement - including constraints - and we should also include the entire linear programming problem statement in the previous section.
 % summarizes all the methods available for solving minimization problems of the type:
 %\begin{equation}
@@ -71,42 +71,6 @@ subproblem than \texttt{trust-ncg}, but it does not require the Hessian to be st
 While most \texttt{minimize} development prior to SciPy 1.0 has focused on unconstrained minimization, 
 % methods \texttt{SLSQP} and \texttt{COBYLA}\footnote{We note that any equality constraint $c_{\text{eq}}(x) = 0$ can be expressed as two inequality constraints $c_{\text{eq}}(x) \leq 0$ and $-c_{\text{eq}}(x) \leq 0$} 
 \texttt{SLSQP} supports fully general nonlinear programming. However, it does not provide special treatment for sparsity, limiting its utility to small problems. Accordingly, ongoing development efforts for \texttt{minimize} are focused on the addition of nonlinear programming algorithms for large, sparse problems. 
-
-\begin{table}[H]
-  \centering
-  \caption{Recently-added optimization methods from \texttt{minimize}, which solves problems of the form $\min_x f(x)$, where $x \in \mathbb{R}^n$ and $f: \mathbb{R}^n \rightarrow \mathbb{R}$ .  The field \textit{version added} specifies the algorithm's first appearance in SciPy. 
-    The field \textit{wrapper} indicates whether the implementation available in SciPy wraps a function written in a compiled language
-    (e.g. C or FORTRAN). First and second order derivates are required for all methods in the table. 
-    \textit{Iterative Hessian factorization} denotes algorithms that factorize the Hessian in an iterative way,
-    which does not require explicit matrix factorization or storage of the Hessian.
-    \textit{Local convergence} gives a lower bound on the rate of convergence of the iterations sequence once the
-    iterate is sufficiently close to the solution: linear (L), superlinear (S) and quadratic (Q). Convergence rates denoted S$^*$ indicate that the algorithm
-    has a superlinear rate for the parameters used in SciPy, but can achieve a quadratic convergence rate with other parameter choices.
-    These algorithms all guarantee convergence to a stationary
-    point (i.e. a point $x^*$ for which $\nabla f(x^*) = 0$); this is \emph{not} a guarantee of convergence to a global minimum. None of the listed algorithms 
-    can deal with constraints on the variables. A similar analysis for optimization algorithms added in older versions of SciPy is available in Table~\ref{tab:minimize-si}.}
-
-  \begin{tabular}{ccccc}
-      & \rotatebox{80}{\texttt{dogleg}} & \rotatebox{80}{\texttt{trust-ncg}} & \rotatebox{80}{\texttt{trust-exact}} & \rotatebox{80}{\texttt{trust-krylov}} \\
-    \hline
-    Version added & 0.13 & 0.13 & 0.19 & 1.0 \\
-    \hline
-    Wrapper & & & & \cmark \\
-    \hline
-    \makecell{Iterative Hessian \\
-    factorization} &  & \cmark &  & \cmark \\
-    \hline
-    Local convergence& Q & S$^*$ & Q & S$^*$  \\
-    \hline
-    \makecell{Line-search (LS) or\\ trust-region (TR)} & TR & TR & TR & TR \\
-    \hline
-    References &
-      \cite{powell_new_1970, nocedal_numerical_2006} &  \cite{steihaug_conjugate_1983, nocedal_numerical_2006} &
-      \cite{conn_trust_2000, more_computing_1983} & \cite{gould_solving_1999, lenders_trlib:_2016} \\
-    \hline
-  \end{tabular}
-  \label{tab:minimize}
-\end{table}
 
 
 \paragraph{Global Minimization}

--- a/scipy-1.0/scipy-optimize.tex
+++ b/scipy-1.0/scipy-optimize.tex
@@ -30,9 +30,10 @@ Compared to the previously implemented simplex method, the new interior-point me
 \subsubsection*{Nonlinear Optimization}
 \paragraph{Local Minimization}
 
-The \texttt{minimize} function provides methods for finding local minima of nonlinear optimization
-problems. It unifies several methods with a common interface in order to facilitate
-interchanging between solvers with different characteristics, summarized in Table~\ref{tab:minimize}.
+The \texttt{minimize} function provides methods for finding local minima of
+nonlinear optimization problems. It unifies several methods with a common 
+interface in order to facilitate interchanging between solvers with different
+characteristics. Some recent improvements are summarized in Table~\ref{tab:minimize}.
 %% Currently, this introduces a ton of whitespace around a very simple expression (min f(x)). The reader can easily find the standard of meaning of `nonlinear programming', so I believe it should be removed. If we decide that it is appropriate to include, then we should add the entire problem statement - including constraints - and we should also include the entire linear programming problem statement in the previous section.
 % summarizes all the methods available for solving minimization problems of the type:
 %\begin{equation}
@@ -73,58 +74,40 @@ While most \texttt{minimize} development prior to SciPy 1.0 has focused on uncon
 
 \begin{table}[H]
   \centering
-  \caption{Optimization methods from \texttt{minimize}, which solves problems of the form $\min_x f(x)$, where $x \in \mathbb{R}^n$ and $f: \mathbb{R}^n \rightarrow \mathbb{R}$ .  The field \textit{version added} specifies the algorithm's first appearance in SciPy. Algorithms with \textit{version added} ``0.6*'' were added in version 0.6 or before.
+  \caption{Recently-added optimization methods from \texttt{minimize}, which solves problems of the form $\min_x f(x)$, where $x \in \mathbb{R}^n$ and $f: \mathbb{R}^n \rightarrow \mathbb{R}$ .  The field \textit{version added} specifies the algorithm's first appearance in SciPy. 
     The field \textit{wrapper} indicates whether the implementation available in SciPy wraps a function written in a compiled language
-    (e.g. C or FORTRAN). The fields \textit{\nth{1}} and \textit{\nth{2} derivatives}
-    indicates whether first or second order derivatives are required. When \textit{\nth{2} derivatives} is flagged
-    with $\sim$ the algorithm does not requires second-order derivatives from
-    the user; it computes an approximation internally and uses it to accelerate method convergence.
+    (e.g. C or FORTRAN). First and second order derivates are required for all methods in the table. 
     \textit{Iterative Hessian factorization} denotes algorithms that factorize the Hessian in an iterative way,
     which does not require explicit matrix factorization or storage of the Hessian.
     \textit{Local convergence} gives a lower bound on the rate of convergence of the iterations sequence once the
     iterate is sufficiently close to the solution: linear (L), superlinear (S) and quadratic (Q). Convergence rates denoted S$^*$ indicate that the algorithm
-    has a superlinear rate for the parameters used in SciPy, but can  achieve a quadratic convergence rate with other parameter choices.
-    \textit{Global convergence} is marked for the algorithms with guarantees of convergence to a stationary
-    point (i.e. a point $x^*$ for which $\nabla f(x^*) = 0$); this is \emph{not} a guarantee of convergence to a global minimum. The table also indicates which algorithms
-    can deal with constraints on the variables. We distinguish between: \textit{bound constraints} (i.e. $x^l \le x \le x^u$),
-    \textit{equality constraints} (i.e. $c_{\text{eq}}(x) = 0$) and \textit{inequality constraints} (i.e. $c_{\text{ineq}}(x) \ge 0$).}
-  \begin{tabular}{cccccccccccccc}
-      & \rotatebox{80}{\texttt{Nelder-Mead}} & \rotatebox{80}{\texttt{Powell}} & \rotatebox{80}{\texttt{COBYLA}} & \rotatebox{80}{\texttt{CG}} & \rotatebox{80}{\texttt{BFGS}}&  \rotatebox{80}{\texttt{L-BFGS-B}} & \rotatebox{80}{\texttt{SLSQP}} & \rotatebox{80}{\texttt{TNC}} & \rotatebox{80}{\texttt{Newton-CG}} & \rotatebox{80}{\texttt{dogleg}} & \rotatebox{80}{\texttt{trust-ncg}} & \rotatebox{80}{\texttt{trust-exact}} & \rotatebox{80}{\texttt{trust-krylov}} \\
+    has a superlinear rate for the parameters used in SciPy, but can achieve a quadratic convergence rate with other parameter choices.
+    These algorithms all guarantee convergence to a stationary
+    point (i.e. a point $x^*$ for which $\nabla f(x^*) = 0$); this is \emph{not} a guarantee of convergence to a global minimum. None of the listed algorithms 
+    can deal with constraints on the variables. A similar analysis for optimization algorithms added in older versions of SciPy is available in Table~\ref{tab:minimize-si}.}
+
+  \begin{tabular}{ccccc}
+      & \rotatebox{80}{\texttt{dogleg}} & \rotatebox{80}{\texttt{trust-ncg}} & \rotatebox{80}{\texttt{trust-exact}} & \rotatebox{80}{\texttt{trust-krylov}} \\
     \hline
-    Version added &  0.6* &  0.6* &  0.6* &  0.6* &  0.6* &  0.6* &  0.9 &  0.6* &  0.6* & 0.13 & 0.13 & 0.19 & 1.0 \\
+    Version added & 0.13 & 0.13 & 0.19 & 1.0 \\
     \hline
-    Wrapper & & & \cmark & & & \cmark & \cmark & \cmark & &  & & & \cmark \\
-    \hline
-    \nth{1} derivatives &  & & & \cmark  & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark \\
-    \hline
-    \nth{2} derivatives &  &  &  &  & $\sim$ & $\sim$ & $\sim$ & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark \\
+    Wrapper & & & & \cmark \\
     \hline
     \makecell{Iterative Hessian \\
-    factorization} & & & &  & & & & \cmark & \cmark &  & \cmark &  & \cmark \\
+    factorization} &  & \cmark &  & \cmark \\
     \hline
-    Local convergence& & & & L & S &  L & S & S$^*$ & S$^*$ & Q & S$^*$ & Q & S$^*$  \\
+    Local convergence& Q & S$^*$ & Q & S$^*$  \\
     \hline
-    Global convergence & & &  &   & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark & \cmark  \\
+    \makecell{Line-search (LS) or\\ trust-region (TR)} & TR & TR & TR & TR \\
     \hline
-    \makecell{Line-search (LS) or\\ trust-region (TR)} & Neither  & LS &  TR & LS & LS & LS & LS & LS & LS & TR & TR & TR & TR \\
-    \hline
-    Bound constraints &&&\cmark&&&&\cmark&\cmark&\cmark&&&& \\
-    \hline
-    Equality constraints &&&&&&&\cmark&&&&& \\
-    \hline
-    Inequality constraint &&&\cmark&&&&\cmark&&&&& \\
-    \hline
-    References & \cite{nelder_simplex_1965, wright_direct_1996} & \cite{powell_efficient_1964} &
-      \cite{powell_direct_1994, powell_direct_1998, powell_view_2007} &
-      \cite{polak_note_1969, nocedal_numerical_2006} & \cite{nocedal_numerical_2006} & \cite{byrd_limited_1995, zhu_algorithm_1997} &
-      \cite{schittkowski_nonlinear_1982, schittkowski_nonlinear_1982-1, schittkowski_convergence_1983, kraft_software_1988} &
-      \cite{nash_newton-type_1984} & \cite{nocedal_numerical_2006}  & 
+    References &
       \cite{powell_new_1970, nocedal_numerical_2006} &  \cite{steihaug_conjugate_1983, nocedal_numerical_2006} &
       \cite{conn_trust_2000, more_computing_1983} & \cite{gould_solving_1999, lenders_trlib:_2016} \\
     \hline
   \end{tabular}
   \label{tab:minimize}
 \end{table}
+
 
 \paragraph{Global Minimization}
 As \texttt{minimize} only seeks a local minimum, some problems require the use of a global optimization routine to find the minimum of the objective function over the set of all decision variable values, especially if the objective function possesses many local minima that other solvers could get stuck in. % e.g. if there is concern that `minimize` could get stuck in an unacceptable local minimum?

--- a/scipy-1.0/scipy-optimize.tex
+++ b/scipy-1.0/scipy-optimize.tex
@@ -33,7 +33,8 @@ Compared to the previously implemented simplex method, the new interior-point me
 The \texttt{minimize} function provides methods for finding local minima of
 nonlinear optimization problems. It unifies several methods with a common 
 interface in order to facilitate interchanging between solvers with different
-characteristics. Some recent improvements are summarized in Table~\ref{tab:minimize-si}.
+characteristics. Characteristics of the different methods are summarized in 
+Table~\ref{tab:minimize-si}.
 %% Currently, this introduces a ton of whitespace around a very simple expression (min f(x)). The reader can easily find the standard of meaning of `nonlinear programming', so I believe it should be removed. If we decide that it is appropriate to include, then we should add the entire problem statement - including constraints - and we should also include the entire linear programming problem statement in the previous section.
 % summarizes all the methods available for solving minimization problems of the type:
 %\begin{equation}


### PR DESCRIPTION
For checklist items from #65:

> - **Nonlinear optimization**
>    - **Local**
> - [ ] Table 1 is nice; the sentence citing it should mention that it includes some of the more recent additions since we're still in the umbrella of key / recent technical improvements
> - [ ] that said, Table 1 also includes additions from as far back as SciPy 0.6 -- which is a longer time span than "last 3 years" for the improvements section as a whole...
>    -  [ ] what about i.e., a dashed vertical line / highlight of some sort dividing "last 3 years" and "before that" in the Table?
>  - [ ] The Table caption is very detailed, but I'm a little concerned about its size -- could we cut it down a bit and move some of the heavy details to i.e., supporting information?

The approach drafted in this PR cuts the Table down to just the recent improvements & abstracts the rest to another Table in the SI.

This provided some opportunity to cut down the caption and table itself in main body of text. There may be more opportunities for simplification, but let's open this for review before I over-optimize the optimize section.