### PR TITLE
Change roadmap summary of ndimage

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1206,7 +1206,8 @@ Some additional roadmap items are summarized in Table~\ref{table:roadmap}.
     \texttt{signal} & migrate spline functionality to \texttt{interpolate}\\
     \texttt{signal} & Second Order Sections update to match capabilities in other routines\\
     \texttt{linalg} & support a more recent version of LAPACK\\
-    \texttt{ndimage} & migrate to data point model from pixel model\\
+    \texttt{ndimage} & clarify usage of the ``data point'' coordinate
+    model, and add additional wrapping modes\\
     \texttt{sparse} & incorporate sparse arrays from Sparse package\cite{abbasi2018sparse} \\
     \texttt{sparse.linalg} & add PROPACK wrappers for faster SVD\\
     \texttt{spatial} & add support for (quaternion) rotation matrices\\


### PR DESCRIPTION
The roadmap description for `ndimage` recently changed: https://scipy.github.io/devdocs/roadmap-detailed.html

Updated the paper summary accordingly.