### PR TITLE
Benchmark Suite

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1026,16 +1026,16 @@ inclusion of additional vendored code.}
 
 \subsubsection*{Benchmark suite}
 
-The airspeed velocity (asv\cite{asvref}) library enables benchmarking Python packages
+The airspeed velocity (\texttt{asv}\cite{asvref}) library enables benchmarking Python packages
 over their lifetimes, and the performance of the SciPy code base was monitored
-with asv starting in February of 2015 (PR \#4501). In addition to ensuring that
+with \texttt{asv} starting in February of 2015 (PR \#4501). In addition to ensuring that
 unit tests are passing (see Test suite section below), confirming 
 that performance generally
 remains constant or improves over the commit hash history of the project allows
 us to objectively measure that our code base is improving, to empower
 scientific applications.
 
-Consider the asv benchmark results shown in Figure~\ref{fig:asvbench}, spanning
+Consider the (\texttt{asv} benchmark results shown in Figure~\ref{fig:asvbench}, spanning
 roughly nine years of project history. These demonstrate the gradual
 performance improvements in a nearest-neighbor search through
 \texttt{scipy.spatial.cKDTree.query()}, and can be run using:
@@ -1049,11 +1049,11 @@ that is packaged with SciPy.
 \begin{figure}[H]
 \centering
 \includegraphics[width=\textwidth]{static/asv_time_query_ckdtree}
-\caption{Airspeed velocity benchmarks for \texttt{scipy.spatial.cKDTree.query()}
+\caption{Airspeed velocity benchmarks for \texttt{scipy.spatial.cKDTree.query}
 over a roughly nine year commit history time frame. The results are based on
 Python 2.7 performance on the master branch of the project using NumPy 1.8.2
 and Cython versions 0.27.3, 0.21.1, and 0.18 (for improved backward
-compatibility). Only the L2 (Euclidean) norm is shown here, and to improve
+compatibility). Only the $L^2$ (Euclidean) norm is shown here, and to improve
 backward compatibility and sampling of the benchmarks there was no application
 of toroidal topology to the \texttt{KDTree} (boxsize argument was ignored).}
 \label{fig:asvbench}
@@ -1061,7 +1061,7 @@ of toroidal topology to the \texttt{KDTree} (boxsize argument was ignored).}
 
 Any pull request can be compared against the \texttt{master} branch with the
 command \texttt{asv continuous master new-feature}. This will provide a
-benchmark against the master branch and the branch a new feature is implemented
+benchmark against the \texttt{master} branch and the branch a new feature is implemented
 in. More features are available in the \texttt{asv} documentation\cite{asvdocs}, including 
 arguments to select which benchmarks to run.
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1029,7 +1029,7 @@ inclusion of additional vendored code.}
 The airspeed velocity (\texttt{asv}\cite{asvref}) library enables benchmarking Python packages
 over their lifetimes, and the performance of the SciPy code base was monitored
 with \texttt{asv} starting in February of 2015 (PR \#4501). In addition to ensuring that
-unit tests are passing (see Test suite section below), confirming 
+unit tests are passing, confirming 
 that performance generally
 remains constant or improves over the commit hash history of the project allows
 us to objectively measure that our code base is improving, to empower

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -948,47 +948,6 @@ the only multivariate discrete distribution available in SciPy.
 
 \subsection*{Test and benchmark suite}
 
-\subsubsection*{Benchmark suite}
-
-The airspeed velocity (asv\cite{asvref}) library enables benchmarking Python packages
-over their lifetimes, and the performance of the SciPy code base was monitored
-with asv starting in February of 2015 (PR \#4501). In addition to ensuring that
-unit tests are passing (see Test suite section below), confirming 
-that performance generally
-remains constant or improves over the commit hash history of the project allows
-us to objectively measure that our code base is improving, to empower
-scientific applications.
-
-Consider the asv benchmark results shown in Figure~\ref{fig:asvbench}, spanning
-roughly nine years of project history. These demonstrate the gradual
-performance improvements in a nearest-neighbor search through
-\texttt{scipy.spatial.cKDTree.query()}, and can be run using:
-
-\texttt{python run.py run -e -s 800 --bench "\textbackslash
-btime\_query\textbackslash b" "02de46a546..b3ddb2c"},
-
-where \texttt{run.py} is a light wrapper script around \texttt{asv}
-that is packaged with SciPy.
-
-\begin{figure}[H]
-\centering
-\includegraphics[width=\textwidth]{static/asv_time_query_ckdtree}
-\caption{Airspeed velocity benchmarks for \texttt{scipy.spatial.cKDTree.query()}
-over a roughly nine year commit history time frame. The results are based on
-Python 2.7 performance on the master branch of the project using NumPy 1.8.2
-and Cython versions 0.27.3, 0.21.1, and 0.18 (for improved backward
-compatibility). Only the L2 (Euclidean) norm is shown here, and to improve
-backward compatibility and sampling of the benchmarks there was no application
-of toroidal topology to the \texttt{KDTree} (boxsize argument was ignored).}
-\label{fig:asvbench}
-\end{figure}
-
-Any pull request can be compared against the \texttt{master} branch with the
-command \texttt{asv continuous master new-feature}. This will provide a
-benchmark against the master branch and the branch a new feature is implemented
-in. More features are available in the \texttt{asv} documentation\cite{asvdocs}, including 
-arguments to select which benchmarks to run.
-
 \subsubsection*{Test suite}
 
 The SciPy test suite is orchestrated by a continuous integration matrix that
@@ -1064,6 +1023,47 @@ inclusion of additional vendored code.}
 \end{figure}
 
 % NOTE: is there a citation for PyPy?
+
+\subsubsection*{Benchmark suite}
+
+The airspeed velocity (asv\cite{asvref}) library enables benchmarking Python packages
+over their lifetimes, and the performance of the SciPy code base was monitored
+with asv starting in February of 2015 (PR \#4501). In addition to ensuring that
+unit tests are passing (see Test suite section below), confirming 
+that performance generally
+remains constant or improves over the commit hash history of the project allows
+us to objectively measure that our code base is improving, to empower
+scientific applications.
+
+Consider the asv benchmark results shown in Figure~\ref{fig:asvbench}, spanning
+roughly nine years of project history. These demonstrate the gradual
+performance improvements in a nearest-neighbor search through
+\texttt{scipy.spatial.cKDTree.query()}, and can be run using:
+
+\texttt{python run.py run -e -s 800 --bench "\textbackslash
+btime\_query\textbackslash b" "02de46a546..b3ddb2c"},
+
+where \texttt{run.py} is a light wrapper script around \texttt{asv}
+that is packaged with SciPy.
+
+\begin{figure}[H]
+\centering
+\includegraphics[width=\textwidth]{static/asv_time_query_ckdtree}
+\caption{Airspeed velocity benchmarks for \texttt{scipy.spatial.cKDTree.query()}
+over a roughly nine year commit history time frame. The results are based on
+Python 2.7 performance on the master branch of the project using NumPy 1.8.2
+and Cython versions 0.27.3, 0.21.1, and 0.18 (for improved backward
+compatibility). Only the L2 (Euclidean) norm is shown here, and to improve
+backward compatibility and sampling of the benchmarks there was no application
+of toroidal topology to the \texttt{KDTree} (boxsize argument was ignored).}
+\label{fig:asvbench}
+\end{figure}
+
+Any pull request can be compared against the \texttt{master} branch with the
+command \texttt{asv continuous master new-feature}. This will provide a
+benchmark against the master branch and the branch a new feature is implemented
+in. More features are available in the \texttt{asv} documentation\cite{asvdocs}, including 
+arguments to select which benchmarks to run.
 
 \section*{Project organization and community}
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1026,7 +1026,7 @@ inclusion of additional vendored code.}
 
 \subsubsection*{Benchmark suite}
 
-The airspeed velocity (\texttt{asv}\cite{asvref}) library enables benchmarking Python packages
+The Airspeed Velocity (\texttt{asv}\cite{asvref}) library enables benchmarking Python packages
 over their lifetimes, and the performance of the SciPy code base was monitored
 with \texttt{asv} starting in February of 2015 (PR \#4501). In addition to ensuring that
 unit tests are passing, confirming 


### PR DESCRIPTION
Moved benchmark suite after test suite because benchmark suite section refers to unit test suite section. Easier for reader to remember the previous paragraph than look ahead. Also a few stylization fixes.

Please consider:

1. removing 1) the command to generate the figure (or moving it into the caption) and 2) and the material after the figure about how to use `asv`. To me it seemed like a short tutorial on how to use `asv` with SciPy, which seemed out of place. If the intent is to advertise the ease of generating such results - which is a great new feature - a description of the capabilities of the `run` script would work
2. removing the last part of "allows us to objectively measure that our code base is improving~~, to empower scientific applications.~~"
3. rewording "generally remains constant or improves over the commit hash history of the project" -> "improves over time."
4. rewording "the performance of the SciPy codebase _was_ monitored with `asv` _starting in_" -> "the performance of the SciPy codebase _has been_ monitored with `asv` _since_"
5. moving the thought "in addition to ensuring that unit tests are passing" to the beginning of the paragraph, which would be right after the unit tests paragraph - a nice segue. 

Perhaps:
In addition to ensuring that unit tests are passing, it is important to confirm that the
the performance of the SciPy codebase improves over time. Since February 2015, the 
performance of SciPy has been monitored with Airspeed Velocity (`asv` \cite{asvref}). 
SciPy's `run.py` script conveniently wraps `asv` features such that benchmark results 
over time can be generated with a single console command. For example, 
Figure~\ref{fig:asvbench} illustrates the improvement of `scipy.spatial.cKDTree.query` 
over roughly nine years of project history.
 


