### PR TITLE
Project organization - Governance

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1073,7 +1073,7 @@ the governance model with the community on the mailing list.  In practice, the
 overruling authority of the BDFL is anticipated to be used only when the
 Steering Council cannot agree on a matter.  The BDFL is expected to consider
 any strong indications that they should step down; although the BDFL may
-appoint a successor it is generally expected that the Steering Council will be
+appoint a successor, it is generally expected that the Steering Council will be
 consulted on the matter.
 
 The (currently) 18 member Steering Council is chaired by Ralf Gommers and

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1078,7 +1078,7 @@ consulted on the matter.
 
 The (currently) 18 member Steering Council is chaired by Ralf Gommers and
 performs a number of tasks including nominating and voting on new Council
-Members, and actively contributing to the progress of the project (could be
+Members and actively contributing to the progress of the project (could be
 code review but also outreach activities, etc.). Generally, one year of sustained
 and substantial contributions (not restricted to source code contributions)
 that improve the project are the prerequisites for nomination of new Council

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1095,7 +1095,7 @@ community. We also describe in some detail how institutional partners may
 contribute to the project, but no financial weight from grants or other sources
 may be leveraged to circumvent or overrule the technical direction of the
 project decided upon by the Steering Committee. The Chair does not have a fixed
-term, but is nominated by the Steering Committee and is expected to yield to
+term but is nominated by the Steering Committee and is expected to yield to
 substantive claims that stepping down is the appropriate action.
 
 SciPy adopted an official Code of Conduct on October 24, 2017


### PR DESCRIPTION
Minor grammatical edits.

If we want to keep all the current content, which is a fine but substantial (~467 word) summary of the governance document and Code of Conduct, I have other suggestions. But do we have space for all of this content?

Here is a reduced version to consider (~215 words).

---
SciPy adopted an official Governance Document on August 3, 2017\cite{SciPyProjectGovernance}.  A Steering Council, currently composed of 18 members, oversees daily development of the project by contributing code and reviewing contributions from the community. Council Members have commit rights to the project repository, but they are expected to merge changes only when there are no substantive community objections. The Chair of the Steering Council, Ralf Gommers, is responsible for initiating biannual technical reviews of project direction and summarizing any private Council activities to the broader community. The project's Benevolent Dictator for Life (BDFL), Pauli Virtanen, has overruling authority on any matter, but the BDFL is expected to act in good faith and only exercise this authority when the Steering Council cannot reach agreement.  

SciPy's official Code of Conduct was approved on October 24, 2017. In summary, there are five Specific Guidelines: 
\emph{be open} to everyone participating in our community; 
\emph{be empathetic and patient} in resolving conflicts; 
\emph{be collaborative}, as we depend on each other to build the library; 
\emph{be inquisitive}, as early identification of issues can prevent serious consequences; and 
\emph{be careful with wording}. 
The Code of Conduct specifies how breaches can be reported to the Code of Conduct Committee, and outlines procedures for the Committee's response. Our Diversity Statement "welcomes and encourages participation by everyone".