### PR TITLE
Community beyond

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1127,7 +1127,7 @@ is often transferred in some form to the other. At the codebase
 level, the \texttt{binned\_statistic} functionality
 is one such cross-project contribution---it was initially
 developed in an Astropy-affiliated package
-and then placed in SciPy after the fact.
+and then placed in SciPy afterwards.
 
 \subsection*{Maintainers and contributors}
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1120,7 +1120,7 @@ of domain-specific software libraries building on top
 of SciPy features, and then returning to the base SciPy library
 to suggest and even implement improvements to enable
 more effective science applications. For example, there
-are common contributors to the SciPy and astropy core
+are common contributors to the SciPy and Astropy core
 libraries\cite{astropy-2018}, and what works well for 
 one of the code bases, infrastructures, or communities 
 is often transferred in some form to the other. At the code

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1122,9 +1122,9 @@ to suggest and even implement improvements to enable
 more effective science applications. For example, there
 are common contributors to the SciPy and Astropy core
 libraries\cite{astropy-2018}, and what works well for 
-one of the code bases, infrastructures, or communities 
-is often transferred in some form to the other. At the code
-base level, the \texttt{binned\_statistic} functionality
+one of the codebases, infrastructures, or communities 
+is often transferred in some form to the other. At the codebase 
+level, the \texttt{binned\_statistic} functionality
 is one such cross-project contribution---it was initially
 developed in an Astropy-affiliated package
 and then placed in SciPy after the fact.


### PR DESCRIPTION
Minimal changes.
Other suggestions I can put in this PR if they sound like a good idea:

1. The "Governance" and "Maintainers and contributors" subsections are focused on SciPy itself (internal). "Commmunity beyond the SciPy library" is about relationships with other projects (external), but its sandwiched between the other two internal sections. I would suggest making the order "Governance", "Maintainers and contributors", and "Community beyond the SciPy library".
2. This "Project organization and community" section is all about how the SciPy project works. The "Governance" subsection is about the official leadership roles, like the government of a city. The "Maintainers and contributors" subsection is about the people, like the citizens. The "Community beyond the SciPy library" subsection - as written - focuses on relationships with other projects, like neighboring cities. It's much more specific than the title "Community beyond the SciPy library" currently suggests. I think it would make the subsection - and the section as a whole - feel more complete if the title were more specific. Something like "Reciprocal projects"? "Sister projects"? "Symbiotic projects"? 
3. "then returning to the base SciPy library to suggest and even implement improvements _to enable more effective science applications_" could be removed or made more specific to avoid sounding empty. Is this supposed to evoke the thought that the domain-specific libraries want the code they have developed to be available for use in other domains, and they turn to SciPy to make that possible?
