### PR TITLE
Discussion

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1145,9 +1145,9 @@ Guide\cite{scipy-dev-guide} provides guidance on how to do that.
 
 SciPy has a strong developer community and a massive user base. GitHub traffic
 metrics report roughly 20,000 unique visitors to the source website between May
-14 and May 27, 2018, with 721 unique copies (``clones") of the code base over
+14 and May 27, 2018, with 721 unique copies (``clones") of the codebase over
 that roughly two-week period. The developer community at that time consisted of 610 unique
-contributors of source code, with $>19,000$ commits accepted into the code base
+contributors of source code, with $>19,000$ commits accepted into the codebase
 (GitHub page data).
 
 From the user side, there were 13,096,468 downloads of SciPy from the Python
@@ -1158,8 +1158,8 @@ website\cite{SciPylib}, which has been the default citation in the absence of a
 peer-reviewed paper, has been cited $>3000$ times. Some of the most prominent
 usages of or demonstrations of credibility for SciPy include the LIGO / Virgo
 scientific collaboration that lead to the observation of gravitational waves
-\cite{PhysRevLett.116.061102}, and the fact that SciPy is shipped directly with
-MacOS and in the Intel Distribution for Python\cite{intel-python}. SciPy is used
+\cite{PhysRevLett.116.061102}, the fact that SciPy is shipped directly with
+MacOS and in the Intel Distribution for Python\cite{intel-python}, and that SciPy is used
 by 47 \% of all machine learning projects on GitHub\cite{octoverse-scipy}.
 
 The SciPy Roadmap\cite{SciPy_roadmap_1,SciPy_roadmap_dev} is a

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -647,9 +647,7 @@ called PyData.
 At the time of writing, the SciPy library consists of nearly 
 600,000 lines of code organized in 16 subpackages. 
 Over 85,000 GitHub repositories and almost 5000 packages depend
-on SciPy. SciPy's GitHub repository attracts approximately 20,000 unique 
-visitors every two weeks, and more than 100 people contribute to a 
-new release every six months. Some of the major
+on SciPy. Some of the major
 feature highlights from the three years preceding
 SciPy 1.0 are discussed in Section \ref{sec:technical_improvements}, 
 and milestones in its history are highlighted in Figure~\ref{fig:timeline}.
@@ -1148,7 +1146,7 @@ Guide\cite{scipy-dev-guide} provides guidance on how to do that.
 SciPy has a strong developer community and a massive user base. GitHub traffic
 metrics report roughly 20,000 unique visitors to the source website between May
 14 and May 27, 2018, with 721 unique copies (``clones") of the code base over
-that roughly two-week period. The developer community consists of 610 unique
+that roughly two-week period. The developer community at that time consisted of 610 unique
 contributors of source code, with $>19,000$ commits accepted into the code base
 (GitHub page data).
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1143,12 +1143,7 @@ Guide\cite{scipy-dev-guide} provides guidance on how to do that.
 
 \section*{Discussion}
 
-\fixme{The Discussion should be succinct and must not contain subheadings.}
-
-\subsection*{Impact now}
-
-% While Paul was one of the early adopters at the national laboratories,
-% Python's presence is now ubiquitous.
+% The Discussion should be succinct and must not contain subheadings.
 
 SciPy has a strong developer community and a massive user base. GitHub traffic
 metrics report roughly 20,000 unique visitors to the source website between May
@@ -1168,8 +1163,6 @@ scientific collaboration that lead to the observation of gravitational waves
 \cite{PhysRevLett.116.061102}, and the fact that SciPy is shipped directly with
 MacOS and in the Intel Distribution for Python\cite{intel-python}. SciPy is used
 by 47 \% of all machine learning projects on GitHub\cite{octoverse-scipy}.
-
-\subsection*{Future Work}
 
 The SciPy Roadmap\cite{SciPy_roadmap_1,SciPy_roadmap_dev} is a
 continuously-updated document


### PR DESCRIPTION
We're not allowed to have subheadings in the discussion, so I removed them. I also removed the 20,000 visitors figure from SciPy Today, as the same figure appeared in this section.

There are a few remaining issues. 

1. We mention LIGO here for a second time. It probably needs to be removed.
2. I think the example Cython syntax should be removed. 
3. We can resurrect the fact that the test suite is in good shape but that vendored code could use better test coverage.

Also consider 4) whether we need to rework the discussion section more substantially. The concern is that a discussion should analyze and interpret what has already been presented, whereas right now half of the discussion is a collection of new facts.

In any case, 5) do we also want some sort of Conclusion section? Right now the paper ends abruptly with the example Cython syntax and the roadmap figure.