### PR TITLE
Swap subsections in Project Organization

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1079,6 +1079,17 @@ SciPy's official Code of Conduct was approved on October 24, 2017. In summary, t
 \emph{be careful with wording}.
 The Code of Conduct specifies how breaches can be reported to a Code of Conduct Committee, and outlines procedures for the Committee's response. Our Diversity Statement ``welcomes and encourages participation by everyone''.
 
+\subsection*{Maintainers and contributors}
+
+The SciPy project has approximately 15 active maintainers---people who review
+others' contributions, and in general do everything needed to ensure that the
+software and the project move forward. Maintainers are critical to the health
+of the project\cite{eghbal2016}; their skills and efforts largely determine how
+fast the project moves forward, and they enable contributions from a much
+larger group. Accordingly, the project also has an additional ~100 unique
+contributors for every 6-monthly release cycle. Anyone with the interest and
+skills can become a contributor or maintainer; the SciPy Developer
+Guide\cite{scipy-dev-guide} provides guidance on how to do that.
 
 \subsection*{Community beyond the SciPy library}
 
@@ -1095,18 +1106,6 @@ level, the \texttt{binned\_statistic} functionality
 is one such cross-project contribution---it was initially
 developed in an Astropy-affiliated package
 and then placed in SciPy afterwards.
-
-\subsection*{Maintainers and contributors}
-
-The SciPy project has approximately 15 active maintainers---people who review
-others' contributions, and in general do everything needed to ensure that the
-software and the project move forward. Maintainers are critical to the health
-of the project\cite{eghbal2016}; their skills and efforts largely determine how
-fast the project moves forward, and they enable contributions from a much
-larger group. Accordingly, the project also has an additional ~100 unique
-contributors for every 6-monthly release cycle. Anyone with the interest and
-skills can become a contributor or maintainer; the SciPy Developer
-Guide\cite{scipy-dev-guide} provides guidance on how to do that.
 
 \section*{Discussion}
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1081,15 +1081,18 @@ The Code of Conduct specifies how breaches can be reported to a Code of Conduct 
 
 \subsection*{Maintainers and contributors}
 
-The SciPy project has approximately 15 active maintainers---people who review
-others' contributions, and in general do everything needed to ensure that the
+The SciPy project has approximately 100 unique contributors
+for every 6-monthly release cycle. Anyone with the interest and
+skills can become a contributor; the SciPy Developer
+Guide\cite{scipy-dev-guide} provides guidance on how to do that.
+In addition, the project currently has 15 active maintainers: people who review
+the contributions of others and do everything else needed to ensure that the
 software and the project move forward. Maintainers are critical to the health
 of the project\cite{eghbal2016}; their skills and efforts largely determine how
-fast the project moves forward, and they enable contributions from a much
-larger group. Accordingly, the project also has an additional ~100 unique
-contributors for every 6-monthly release cycle. Anyone with the interest and
-skills can become a contributor or maintainer; the SciPy Developer
-Guide\cite{scipy-dev-guide} provides guidance on how to do that.
+fast the project moves forward, and they enable input from the much
+larger group of contributors. Anyone can become a maintainer, too, as they
+are selected on a rolling basis from contributors with a significant history of
+high-quality contributions.
 
 \subsection*{Community beyond the SciPy library}
 


### PR DESCRIPTION
The "Governance" and "Maintainers and contributors" subsections are focused on SciPy itself (internal). "Commmunity beyond the SciPy library" is about relationships with other projects (external), but its sandwiched between the other two internal sections. I simply changed the order of subsections to "Governance", "Maintainers and contributors", and "Community beyond the SciPy library"; they are now in order from closest to the core of the project to further away.