### PR TITLE
Sparse / cKDTree tweaks

### DIFF
--- a/scipy-1.0/ckdtree.tex
+++ b/scipy-1.0/ckdtree.tex
@@ -16,14 +16,14 @@ approximate sparse distance matrices between \texttt{KDTree} objects by ignoring
 all distances that exceed a user-provided value. Also, this routine is not 
 limited to the conventional L2 (Euclidean) norm but supports any Minkowski 
 p-norm between 1 and infinity. By default, the returned data structure is a 
-Dictionary Of Keys based sparse matrix (DOK), which is very efficient for matrix 
+Dictionary Of Keys (DOK) based sparse matrix, which is very efficient for matrix 
 construction. This hashing approach to sparse matrix assembly can be 7 times 
-faster than constructing with Compressed Sparse Row format (CSR) 
-\cite{10.1007/978-3-540-75755-9_107} and the C++ level sparse matrix construction 
+faster than constructing with CSR format
+\cite{10.1007/978-3-540-75755-9_107}, and the C++ level sparse matrix construction 
 releases the Python GIL for increased performance. Once the matrix is constructed, 
 distance value retrieval has an amortized constant time complexity 
 \cite{Cormen:2001:IA:580470}, and the DOK structure can be efficiently converted 
-to a CSR, Compressed Sparse Column (CSC) or COOrdinate (COO) matrix to allow for 
+to a CSR, CSC, or COO matrix to allow for 
 speedy arithmetic operations.
 
 In 2015 the \texttt{cKDTree} dual tree counting algorithm\cite{Moore2000ar}

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -823,10 +823,6 @@ Here we describe key technical improvements made in the last three years.
 
 \subsection*{Data structures}
 
-\subsubsection*{\texttt{cKDTree}}
-
-\input{ckdtree}
-
 \subsubsection*{Sparse matrices}
 
 \texttt{scipy.sparse} offers seven sparse matrix data structures,
@@ -851,6 +847,10 @@ available. We've added \texttt{scipy.sparse.norm} and
 random variates from arbitrary distributions, respectively. Also, we've made a
 concerted effort to bring the \texttt{scipy.sparse} API into line with the
 equivalent NumPy API where possible.
+
+\subsubsection*{\texttt{cKDTree}}
+
+\input{ckdtree}
 
 \subsection*{Unified bindings to compiled code}
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -829,7 +829,7 @@ Here we describe key technical improvements made in the last three years.
 also known as sparse formats. The most important ones are the row- 
 and column-compressed formats (CSR and CSC, respectively). 
 These offer fast major-axis indexing and fast matrix-vector multiplication,
-and are used heavily in scikit-learn.
+and are used heavily throughout SciPy and dependent packages.
 
 Over the last three years our sparse matrix handling internals have been
 rewritten and performance has been improved. Iterating over and slicing of CSC


### PR DESCRIPTION
There were duplicate definitions of CSR/CSC format acronyms in adjacent sections sparse and cKDTree. The sparse section seemed a more natural place to define them than right before it in cKDTree, so I swapped the order and removed the duplicate definitions from cKDTree.

(Note: COO and DIA definitions added to sparse in #129)
