### PR TITLE
Community beyond the SciPy library section

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1088,7 +1088,7 @@ For example, there are common contributors to the SciPy and
 Astropy core libraries\cite{astropy-2018}, and what works 
 well for one of the codebases, infrastructures, or communities
 is often transferred in some form to the other. At the codebase
-level, the \texttt{binned_statistic} functionality
+level, the \texttt{binned\_statistic} functionality
 is one such cross-project contribution: it was initially
 developed in an Astropy-affiliated package
 and then placed in SciPy afterwards. 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1081,18 +1081,19 @@ The Code of Conduct specifies how breaches can be reported to a Code of Conduct 
 \subsection*{Downstream projects}
 
 The scientific Python ecosystem includes many examples
-of domain-specific software libraries that are built 
-on top of SciPy features. The work done on these libraries
-often turns out to be beneficial to the whole ecosystem
-being SciPy the catalyst of this cross-fertilisation process. 
+of domain-specific software libraries building on top
+of SciPy features and then returning to the base SciPy library
+to suggest and even implement improvements. 
 For example, there are common contributors to the SciPy and 
 Astropy core libraries\cite{astropy-2018}, and what works 
-well for one of the codebases, infrastructures, or communities 
-is often transferred in some form to the other. At the codebase 
-level, the \texttt{binned\_statistic} functionality
-is one such cross-project contribution---it was initially
+well for one of the codebases, infrastructures, or communities
+is often transferred in some form to the other. At the codebase
+level, the \texttt{binned_statistic} functionality
+is one such cross-project contribution: it was initially
 developed in an Astropy-affiliated package
-and then placed in SciPy afterwards.
+and then placed in SciPy afterwards. 
+In this perspective, SciPy serves as a catalyst for cross-fertilisation 
+throughout the Python scientific computing community.
 
 \subsection*{Maintainers and contributors}
 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1078,7 +1078,7 @@ SciPy's official Code of Conduct was approved on October 24, 2017. In summary, t
 The Code of Conduct specifies how breaches can be reported to a Code of Conduct Committee, and outlines procedures for the Committee's response. Our Diversity Statement ``welcomes and encourages participation by everyone''.
 
 
-\subsection*{Relation with downstream projects}
+\subsection*{Downstream projects}
 
 The scientific Python ecosystem includes many examples
 of domain-specific software libraries that are built 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1084,7 +1084,7 @@ The scientific Python ecosystem includes many examples
 of domain-specific software libraries that are built 
 on top of SciPy features. The work done on these libraries
 often turns out to be beneficial to the whole ecosystem
-being Scipy the catalyst of this cross-fertilisation process. 
+being SciPy the catalyst of this cross-fertilisation process. 
 For example, there are common contributors to the SciPy and 
 Astropy core libraries\cite{astropy-2018}, and what works 
 well for one of the codebases, infrastructures, or communities 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1078,7 +1078,7 @@ SciPy's official Code of Conduct was approved on October 24, 2017. In summary, t
 The Code of Conduct specifies how breaches can be reported to a Code of Conduct Committee, and outlines procedures for the Committee's response. Our Diversity Statement ``welcomes and encourages participation by everyone''.
 
 
-\subsection*{Community beyond the SciPy library}
+\subsection*{Relation with downstream projects}
 
 The scientific Python ecosystem includes many examples
 of domain-specific software libraries that are built 

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -1081,13 +1081,13 @@ The Code of Conduct specifies how breaches can be reported to a Code of Conduct 
 \subsection*{Community beyond the SciPy library}
 
 The scientific Python ecosystem includes many examples
-of domain-specific software libraries building on top
-of SciPy features, and then returning to the base SciPy library
-to suggest and even implement improvements to enable
-more effective science applications. For example, there
-are common contributors to the SciPy and Astropy core
-libraries\cite{astropy-2018}, and what works well for 
-one of the codebases, infrastructures, or communities 
+of domain-specific software libraries that are built 
+on top of SciPy features. The work done on these libraries
+often turns out to be beneficial to the whole ecosystem
+being Scipy the catalyst of this cross-fertilisation process. 
+For example, there are common contributors to the SciPy and 
+Astropy core libraries\cite{astropy-2018}, and what works 
+well for one of the codebases, infrastructures, or communities 
 is often transferred in some form to the other. At the codebase 
 level, the \texttt{binned\_statistic} functionality
 is one such cross-project contribution---it was initially


### PR DESCRIPTION
Starting from discussion on #122

As far as I can see, the message this paragraph is trying to convey is that the communities of downstream projects actively contribute to scipy and by doing so indirectly contibute to other projects. Thus, scipy plays a mediator and meeting point role in the python ecosystem.
 
I don't dislike the current title, but I see @mdhaber point about more specific title and I don't mind changing it. What about "Relation with sibiling projects"? 