### PR TITLE
Added citations to SciPy begins

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -321,9 +321,9 @@ released a number of packages\cite{Travis-some-modules,Travis-enhance}
 that built on top of the Numeric array
 package, and provided algorithms for signal processing, special
 functions, sparse matrices, quadrature, optimization, Fast Fourier
-Transforms, and more.  One of these packages, Multipack, was a set of
+Transforms, and more.  One of these packages, Multipack\cite{multipack}, was a set of
 extension modules that wrapped Fortran and C libraries such as
-ODEPACK, QUADPACK, and MINPACK, to solve and minimize nonlinear
+ODEPACK\cite{citeulike:2644528}, QUADPACK\cite{1983qspa.book.....P}, and MINPACK\cite{osti_6997568}, to solve and minimize nonlinear
 equations, integrate differential equations, and fit splines (the
 latter implemented by Pearu Peterson).  Robert Kern, then an
 undergraduate student (and currently a SciPy core developer), provided
@@ -419,7 +419,7 @@ John Hunter, a postdoc
 %under Kurt Hecox, whereafter at Tradelink from 2006
 at the University
 of Chicago, liked the plotting functionality
-available in MATLAB, but had problems accessing their laboratory's
+available in MATLAB\cite{matlab}, but had problems accessing their laboratory's
 license, which was governed by a hardware dongle.  In response, he
 wrote a plotting library from scratch, and Matplotlib 0.1 was released
 April 2003\cite{matplotlib-rel}.
@@ -444,7 +444,7 @@ problems with the Python numerical array container.
 Numeric, the original array package, was
 suitable for small arrays, but not for the large images processed by
 STScI.  With the Numeric maintainer's blessing, the decision was made
-to write NumArray, a library that could handle data on a larger
+to write NumArray\cite{greenfield2003numarray}, a library that could handle data on a larger
 scale.  Unfortunately, NumArray proved inefficient for small arrays,
 presenting the community with a rather unfortunate choice.  In 2005,
 Travis Oliphant combined the best elements of Numeric and NumArray,

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -1740,3 +1740,24 @@ urldate = {2019-2-15}
    adsurl = {http://adsabs.harvard.edu/abs/2019ApJ...875L...3E},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
+
+@online{multipack,
+author = {{Travis Oliphant}},
+title = {{Multipack (a collection of FORTRAN routines interfaced with NumPy)}},
+url = {http://pylab.sourceforge.net/multipack.html},
+urldate = {2019-05-16}
+}
+
+@BOOK{matlab,
+TITLE = {{MATLAB}},
+PUBLISHER = {The {MathWorks}, Inc.},
+ADDRESS = {Natick, MA, United States},
+}
+
+@article{greenfield2003numarray,
+  title={numarray: A new scientific array package for {Python}},
+  author={Greenfield, Perry and Miller, Jay Todd and Hsu, JT and White, Richard L},
+  journal={PyCon DC},
+  year={2003},
+  publisher={Citeseer}
+}


### PR DESCRIPTION
Added citations to software named in "SciPy Begins" section.
Closes #112 

Note that we cite the Numeric manual in the paragraph above, so I didn't cite Numeric again in this section.  LMK if I should add that.