### PR TITLE
Update affiliation since ICES changed its name recently.

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -86,7 +86,7 @@
 \affil[22]{Affiliation, department, city, postcode, country}
 \affil[23]{Affiliation, department, city, postcode, country}
 \affil[24]{University of Texas at Austin,
-           Institute for Computational Engineering and Sciences,
+           Oden Institute for Computational Engineering and Sciences,
 	   Austin, TX, 78712, USA}
 \affil[25]{Division of Biostatistics, University of California,
   Berkeley, CA, 94720, USA}


### PR DESCRIPTION
Pretty self-explanatory. My institute recently changed names. This uses the updated name.