### PR TITLE
Correct my affiliation (I'm based in Montreal, not Cambridge)

### DIFF
--- a/scipy-1.0/core-dev.tex
+++ b/scipy-1.0/core-dev.tex
@@ -61,5 +61,6 @@
 \affil[26]{Oden Institute for Computational Engineering and Sciences, The University of Texas at Austin, Austin, Texas 78712, USA}
 \affil[27]{Anton Pannekoek Institute, P.O. Box 94249, 1090 GE Amsterdam, The Netherlands}
 \affil[28]{Graduate Program in Electrical Engineering, Universidade Federal de Minas Gerais, 6627 Av. Antonio Carlos 31270-901 Belo Horizonte, Brazil}
-\affil[29]{Google, Inc., 355 Main St., Cambridge, MA 02142, USA}
+\affil[29]{Google LLC, Montreal, QC H3B 2Y5 Canada}
+\affil[30]{Google LLC, 355 Main St., Cambridge, MA 02142, USA}
 \affil[*]{scipy.articles@gmail.com}


### PR DESCRIPTION
It seems that two researchers from Google but different offices are authors in this paper, and I was erroneously attached to the Cambridge address. I took the approach of creating a new entry for me, changing the Cambridge address to Montreal. It would also be fine for me to remove geographical information and have as affiliation simply Google LLC for both me and Paul van Mulbregt (but I would need to check with Paul first).

Also corrected Google Inc. (old affiliation) to Google LLC