### PR TITLE
Small fixes.

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -147,7 +147,7 @@ ecosystem of research software---backed by millions in funding and
 many hundreds of highly qualified engineers\cite{mathworks-globe-97,
 esri-revenue,bloom-wolfram}---was preposterous.
 
-Yet the philosophical motivations behind a fully open toolstack, combined
+Yet the philosophical motivations behind a fully open tool stack, combined
 with an excited, friendly community with a singular focus, have
 proven auspicious in the long run.  They led not only to the library
 described in this paper, but also to an entire ecosystem of related
@@ -1031,7 +1031,7 @@ peer-reviewed paper, has been cited $>3,000$ times\cite{googlescholar}. Some of 
 usages of or demonstrations of credibility for SciPy include the LIGO / Virgo
 scientific collaboration that lead to the observation of gravitational waves
 \cite{PhysRevLett.116.061102}, the fact that SciPy is shipped directly with
-MacOS and in the Intel Distribution for Python\cite{intel-python}, and that SciPy is used
+macOS and in the Intel Distribution for Python\cite{intel-python}, and that SciPy is used
 by 47\% of all machine learning projects on GitHub\cite{octoverse-scipy}.
 
 Nevertheless, SciPy continually strives to improve.

--- a/scipy-1.0/scipy-optimize.tex
+++ b/scipy-1.0/scipy-optimize.tex
@@ -33,7 +33,7 @@ As \texttt{minimize} may return any local minimum, some problems require the use
     The field \textit{wrapper} indicates whether the implementation available in SciPy wraps a function written in a compiled language
     (e.g. C or FORTRAN). The fields \textit{\nth{1}} and \textit{\nth{2} derivatives}
     indicates whether first or second order derivatives are required. When \textit{\nth{2} derivatives} is flagged
-    with $\sim$ the algorithm does not requires second-order derivatives from
+    with $\sim$ the algorithm does not require second-order derivatives from
     the user; it computes an approximation internally and uses it to accelerate method convergence.
     \textit{Iterative Hessian factorization} denotes algorithms that factorize the Hessian in an iterative way,
     which does not require explicit matrix factorization or storage of the Hessian.


### PR DESCRIPTION
- Fix typo.
- Consistently spell "tool stack".
- Use Apple's capitalization of macOS.