### PR TITLE
Python matrix multiplication operator font fix

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -774,7 +774,7 @@ low-level implementations leveraged by a subset of our \texttt{sparse}
 offerings.
 
 From a new features standpoint, \texttt{scipy.sparse} matrices and linear
-operators now support the Python matrix multiplication (@) operator.
+operators now support the Python matrix multiplication (\texttt{@}) operator.
 We've added \texttt{scipy.sparse.norm} and
 \texttt{scipy.sparse.random} for computing sparse matrix norms and drawing
 random variates from arbitrary distributions, respectively. Also, we've made a


### PR DESCRIPTION
Thanks @stsievert for catching this in #180 