### PR TITLE
Fix SciPy 1.0 announcement typos

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -301,19 +301,19 @@ SciPy is an open source package that builds on the strengths of Python and
 Numeric providing a wide range of fast scientific and numeric functionality.
 SciPy's current module set includes the following:
 
-    Special Functions (Bessel, hanker, Airy, etc.)
+    Special Functions (Bessel, Hankel, Airy, etc.) % hanker -> Hankel
     Signal/Image Processing
     2D Plotting capabilities
     Integration
     ODE solvers
-    Optimization (simplex, BFGS, Netwon-CG, etc.)
+    Optimization (simplex, BFGS, Newton-CG, etc.) % Netwon -> Newton
     Genetic Algorithms
     Numeric -> C++ expression compiler
     Parallel programming tools
     Splines and Interpolation
     And other stuff.
 \end{verbatim}
-\caption{Excerpt from SciPy 0.1 release announcement (typos included).}\label{fig:announce-0.1}
+\caption{Excerpt from SciPy 0.1 release announcement (typos corrected).}\label{fig:announce-0.1}
 \end{figure}
 
 With a rich programming environment and a numerical array object in


### PR DESCRIPTION
Adding this alternative to move things along. Thanks for bringing it up @arokem.

Supersedes and Closes #200 

I'd suggest _not_ adding brackets, as the source is cited and it's just not important enough to call attention to the typos. But I will change if majority vote insists.

@endolith, @apbard, @tylerjereddy, @arokem please case your votes 
