### PR TITLE
MAINT: review comment re: GitHub

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -613,7 +613,7 @@ called PyData.
 At the time of writing, the SciPy library consists of nearly
 \num{600000}~lines of code organized in 16~subpackages. The development
 team and community currently interact and operate primarily
-on GitHub---an online central version control and task management platform.
+on GitHub, an online version control and task management platform.
 Over \num{110000}~GitHub repositories and \num{6500}~packages depend
 on SciPy\cite{dependents}. Some of the major
 feature highlights from the three years preceding

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -611,7 +611,9 @@ called PyData.
 
 \subsection*{SciPy Today}
 At the time of writing, the SciPy library consists of nearly
-\num{600000}~lines of code organized in 16~subpackages.
+\num{600000}~lines of code organized in 16~subpackages. The development
+team and community currently interact and operate primarily
+on GitHub---an online central version control and task management platform.
 Over \num{110000}~GitHub repositories and \num{6500}~packages depend
 on SciPy\cite{dependents}. Some of the major
 feature highlights from the three years preceding


### PR DESCRIPTION
Fixes #225 

* address reviewer comment from *Nature Methods* requesting
a brief description of GitHub prior to its first usage
in the text

It also occurs to me that it might be useful to use a LaTeX highlighting markup for the requested changes so that we could optionally compile a PDF with / without the highlighted changes. Maybe that's too complicated, but could save time for the person ultimately submitting the revised doc along with rebuttal.