### PR TITLE
Introduce Continuous integration

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -882,9 +882,15 @@ uncertainity when making code changes\cite{TDD-Beck}. For each component of
 SciPy, we write multiple small executable tests that verify its intended
 behavior. The collection of these, known as a \emph{test suite}, increases
 confidence in the correctness and accuracy of the library, and lets us make
-code modifications known not to alter desired behavior. Monitoring the number
+code modifications known not to alter desired behavior.
+According to the practice of continuous integration, all proposed contributions
+to SciPy are temporarily integrated with the master branch of the library
+before the test suite is run, and all tests must pass before the contribution
+is permanently merged.
+Continuously monitoring the number
 of lines of code in SciPy covered by unit tests is one way we maintain
 some certainty that changes and new features are correctly implemented.
+
 The SciPy test suite is orchestrated by a continuous integration matrix that
 includes POSIX and Windows (32/64-bit) platforms managed by Travis CI and
 AppVeyor, respectively. Our tests cover Python versions 2.7, 3.4, 3.5, 3.6, and

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -878,10 +878,12 @@ and the multinomial distribution in \texttt{scipy.stats.multinomial}
 \subsubsection*{Test suite}
 
 Test-driven development has been described as a way to manage fear and
-uncertainity when making code changes\cite{TDD-Beck}. For each component of SciPy, we write multiple small executable
-tests that verify its intended behavior. The collection of these, known as a \emph{test suite}, increases confidence in
-the correctness and accuracy of the library, and lets us make code modifications known not to alter desired behavior. Monitoring the number of lines
-of code in SciPy covered by unit tests is one way we maintain
+uncertainity when making code changes\cite{TDD-Beck}. For each component of 
+SciPy, we write multiple small executable tests that verify its intended
+behavior. The collection of these, known as a \emph{test suite}, increases
+confidence in the correctness and accuracy of the library, and lets us make
+code modifications known not to alter desired behavior. Monitoring the number
+of lines of code in SciPy covered by unit tests is one way we maintain
 some certainty that changes and new features are correctly implemented.
 The SciPy test suite is orchestrated by a continuous integration matrix that
 includes POSIX and Windows (32/64-bit) platforms managed by Travis CI and

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -883,7 +883,7 @@ SciPy, we write multiple small executable tests that verify its intended
 behavior. The collection of these, known as a \emph{test suite}, increases
 confidence in the correctness and accuracy of the library, and lets us make
 code modifications known not to alter desired behavior.
-According to the practice of continuous integration, all proposed contributions
+According to the practice of continuous integration\cite{silver2017collaborative}, all proposed contributions
 to SciPy are temporarily integrated with the master branch of the library
 before the test suite is run, and all tests must pass before the contribution
 is permanently merged.

--- a/scipy-1.0/references.bib
+++ b/scipy-1.0/references.bib
@@ -1894,3 +1894,13 @@ urldate = {2019-06-30}
   author = {Beck, Kent},
   year = {2003},
 }
+
+@article{silver2017collaborative,
+  title={Collaborative software development made easy},
+  author={Silver, Andrew},
+  journal={Nature News},
+  volume={550},
+  number={7674},
+  pages={143},
+  year={2017}
+}


### PR DESCRIPTION
Close #227 

First commit is just line break adjustments.
Second commit adds a sentence to introduce continuous integration.

This was an attempt to introduce CI without making any changes to surrounding text. Not sure whether it all fits together in the best way, but I think it addresses the comment.