### PR TITLE
Removed paragraph before SciPy Begins

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -221,18 +221,6 @@ This broadens the scope of problems that can be addressed easily, expands the
 sources of data that are readily accessible, and increases the size of the
 community that develops code for the platform.
 
-The availability of a standard numerical array data structure in
-Python led to a sudden, rapid growth in the number of scientific
-packages available for solving common numeric problems.
-A number of these packages were written by graduate students and
-postdoctoral researchers to solve the very practical research problems
-that they faced on a daily basis.  While they had access to and were
-familiar with specialized (often commercial) systems, many found
-it easier to implement the domain-specific functionality they needed
-in a general purpose programming language.  Given Python's innate
-ability to function as a systems language, controlling specialized or
-custom-built hardware was also possible.
-
 %in the Program for Climate Model Diagnosis and Intercomparison at
 %Lawrence Livermore National Laboratory built their Climate Data
 %Analysis Tools (``an open-source set of Python modules and tools for


### PR DESCRIPTION
Partially addresses #222 

The main idea of this paragraph - that the introduction of Numeric led to the growth in the number of scientific packages, many of which were written by students - is captured in the first paragraph of the next section, SciPy Begins. The previous paragraph includes the idea that it was nice to add domain-specific functionality to a general purpose language rather than the other way around.