### PR TITLE
Removed paragraph about founding of NumFocus

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -596,19 +596,6 @@ topics including modeling and simulation, data collection, electrophysiology, vi
 as well as stimulus generation and presentation---called Python in
 Neuroscience\cite{python-FIN}.
 
-In 2012, Perry Greenfield, John Hunter, Jarrod Millman, Travis Oliphant,
-and Fernando Pérez founded NumFOCUS\cite{numfocus},
- a 501(c)3 public charity with a mission
-``to promote sustainable high-level programming languages, open code development,
-and reproducible scientific research.''
-While NumFOCUS is language agnostic, many of the early sponsored projects
-came from the scientific Python stack.
-Today it has 50 affiliated and sponsored projects including NumPy, SciPy, IPython, and
-Matplotlib.
-Among its other projects, NumFOCUS organizes a global network of
-community driven educational programs, meetups, and conferences
-called PyData.
-
 \subsection*{SciPy Today}
 At the time of writing, the SciPy library consists of nearly
 \num{600000}~lines of code organized in 16~subpackages. The development


### PR DESCRIPTION
Partially addresses #222 

It's not really part of the history of SciPy 1.0.
