### PR TITLE
MAINT: reviewer comment re: GPUs, etc.

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -572,7 +572,7 @@ algorithms for in-memory computing on single machines, with support for a wide
 range of data types and process architectures. Distributed computing and support
 for graphics processing units (GPUs) were explicitly out of scope at the 1.0
 release point, but this has been revised in our roadmap at the time of writing
-(see below).
+(see Discussion).
 
 \subsection*{Package organization}
 \input{subpackages}

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -623,10 +623,8 @@ the latest JIT compilation approaches (i.e.,
 Numba\cite{Lam:2015:NLP:2833157.2833162}) are very powerful, but have traditionally fallen
 outside the remit of the main SciPy library. That said, we have recently
 increased our efforts to support compatibility with some of these options, and
-while the exact approach we will adopt across the entire library remains unclear,
-we do now have a concrete implementation of a submodule that allows for the experimental
-use of multiple backends such as GPU-tractable data structures in the new
-\texttt{scipy.fft}. This will be described in detail in a future report.
+our full test suite passed with the PyPy JIT compiler\cite{Bolz:2009:TMP:1565824.1565827}
+at the 1.0 release point.
 
 \subsection*{API and ABI evolution}
 
@@ -999,6 +997,15 @@ migration to typed memoryviews to handle NumPy arrays.
 
 A problem faced by many open source projects is attracting and retaining developers. While it is normal for some individuals to contribute to a project for a while and then move on, too much turnover can result in the loss of institutional memory, leading to mistakes of the past being repeated, APIs of new code becoming inconsistent with the old code, and a drifting project scope.
 We are fortunate that the SciPy project continues to attract enthusiastic and competent new developers while maintaining the involvement of a small but dedicated ``old guard''. There are contributors who were present in the early years of the project who still contribute to discussions of bug reports and reviews of new code contributions. Our BDFL has been with the project for more than 10~years and is still actively contributing code, and the head of our Steering Council, who also acts as a general manager, is approaching his eleventh anniversary. An additional half dozen or so active developers have been contributing steadily for five or more years. The combination of a committed old guard and a host of new contributors ensures that SciPy will continue to grow while maintaining a high level of quality.
+
+A final important challenge to address is the accommodation of GPU and distributed
+computing without disrupting our conventional and heavily-used algorithm / API
+infrastructure. While the exact approach we will adopt across the entire library
+to leverage these emerging technologies remains unclear, and was not a priority
+at the 1.0 release point, we do now have a concrete implementation of a subpackage
+that allows for the experimental use of multiple backends, such as GPU-tractable
+data structures, in the new \texttt{scipy.fft}. This will be described in detail
+in a future report.
 
 \section*{Data Availability}
 % The statement should be provided as a separate section (titled 'Data Availability') at the end of the main text, before the 'References' section.

--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -570,7 +570,9 @@ functionality in SciPy:
 In terms of software systems and architecture, SciPy's scope matches NumPy's:
 algorithms for in-memory computing on single machines, with support for a wide
 range of data types and process architectures. Distributed computing and support
-for graphics processing units (GPUs) are explicitly out of scope.
+for graphics processing units (GPUs) were explicitly out of scope at the 1.0
+release point, but this has been revised in our roadmap at the time of writing
+(see below).
 
 \subsection*{Package organization}
 \input{subpackages}
@@ -618,12 +620,13 @@ foundation of the scientific Python ecosystem is such that adoption of new
 languages or major dependencies is generally unlikely---our choices are strongly
 driven by long-term stability. GPU acceleration, new transpiling libraries, and
 the latest JIT compilation approaches (i.e.,
-Numba\cite{Lam:2015:NLP:2833157.2833162}) are very powerful, but currently fall
+Numba\cite{Lam:2015:NLP:2833157.2833162}) are very powerful, but have traditionally fallen
 outside the remit of the main SciPy library. That said, we have recently
 increased our efforts to support compatibility with some of these options, and
-having our full test suite pass with the PyPy JIT
-compiler\cite{Bolz:2009:TMP:1565824.1565827} is now a requirement in our
-development workflow.
+while the exact approach we will adopt across the entire library remains unclear,
+we do now have a concrete implementation of a submodule that allows for the experimental
+use of multiple backends such as GPU-tractable data structures in the new
+\texttt{scipy.fft}. This will be described in detail in a future report.
 
 \subsection*{API and ABI evolution}
 


### PR DESCRIPTION
Fixes #220 

* both *Nature Methods* reviewers requested clarification
regarding SciPy's stance on staying relevant with GPUs
and distributed computing

* briefly mention that while these were out of scope
at the 1.0 release point, we now have an explicit
example of experimental GPU backend support in `scipy.fft`,
to be detailed in a future report

~We actually stopped testing PyPy on master, so that's a slightly awkward edit.~ This is no doubt contentious, but anyway let's make an effort and try to get it published soon :)