### PR TITLE
WIP: Add git latexdiff script

### DIFF
--- a/scipy-1.0/git_latexdiff.sh
+++ b/scipy-1.0/git_latexdiff.sh
@@ -1,0 +1,4 @@
+# use git-latexdiff to provide a highlighted PDF with changes
+# requested for Nature Methods
+
+git latexdiff --main paper.tex --output paper_diff.pdf 6ff8517237 master


### PR DESCRIPTION
Fixes #249 but work in progress using [git-latexdiff](https://gitlab.com/git-latexdiff/git-latexdiff)

Here's an [early draft of the paper_diff.pdf](https://github.com/scipy/scipy-articles/files/3623828/paper_diff.pdf) that shows up in a temporary directory created by latexdiff when using the script in this PR, but I think I still have issues:

- [ ]  getting the `-o` flag to actually dump the PDF in a chosen working directory (I think this may be related to some compile errors)
- [ ] getting the diff to work on the bibliography (latexdiff seems to struggle with the nested style file hierarchy, maybe)

We may want to touch up the styling a bit too.