### PR TITLE
MAINT: move CI definition

### DIFF
--- a/scipy-1.0/paper.tex
+++ b/scipy-1.0/paper.tex
@@ -519,7 +519,13 @@ and milestones in its history are highlighted in Figure~\ref{fig:timeline}.
 \centering
 \includegraphics[width=0.95\textwidth]{static/scipy_timeline}
 \caption{Major milestones from SciPy's initial release in 2001 to
-the release of SciPy 1.0 in 2017.}
+the release of SciPy 1.0 in 2017. Note that SciKits and GitHub 
+have been introduced in the ``Background'' section;  more 
+information about Cython and SciPy subpackages (e.g. 
+\texttt{scipy.sparse}) is available in ``Architecture 
+and implementation choices'', BLAS/LAPACK support is 
+detailed in ``Key technical improvements'', and continuous
+integration is discussed in ``Test and benchmark suite''.}
 \label{fig:timeline}
 \end{figure}
 


### PR DESCRIPTION
Fixes #252 to move the CI definition prior to the first mention of CI in a Figure, as per reviewer comment.

While the CI definition may be slightly out of place at that point of the article, I'd say checking off the box to satisfy the reviewer comment is more important that some kind of ideal / flawless flow to the paper with all testing content confined to the testing section.

